### PR TITLE
Suppress auto-trigger while WING virtual soundcheck is active

### DIFF
--- a/docs/CC_BUTTONS_AND_AUTO_TRIGGER.md
+++ b/docs/CC_BUTTONS_AND_AUTO_TRIGGER.md
@@ -57,6 +57,9 @@ Auto-trigger is configured in the plugin `Auto Trigger` section and monitors REA
   - warning/record state stops and WING status text/lights are cleared
 - Manual transport interaction:
   - manual play/record suppresses warning behavior to avoid conflicting states
+- Virtual soundcheck interaction:
+  - when ALT source soundcheck mode is active on managed channels, auto-trigger monitoring is suppressed
+  - this state is synced from WING so desk-side mode changes are respected (not only plugin button toggles)
 
 ## 3. SD Recording (Optional)
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -111,6 +111,10 @@ Main controls:
 - `Hold ms`
 - `CC layer` for warning/record status display on WING
 
+Safety behavior:
+
+- Auto-trigger is suppressed while virtual soundcheck mode is active (ALT source enabled on managed channels), including when soundcheck mode is changed directly on WING.
+
 Detailed reference:
 
 - [CC_BUTTONS_AND_AUTO_TRIGGER.md](CC_BUTTONS_AND_AUTO_TRIGGER.md)

--- a/include/wingconnector/reaper_extension.h
+++ b/include/wingconnector/reaper_extension.h
@@ -142,6 +142,7 @@ private:
     // MIDI input handling  
     void ProcessMidiInput(const unsigned char* data, int len);
     void MonitorAutoRecordLoop();
+    bool RefreshSoundcheckModeFromWing();
     void StartAutoRecordMonitor();
     void StopAutoRecordMonitor();
     void QueueManagedSourceMonitorWarning(const std::string& warning);

--- a/src/extension/reaper_extension.cpp
+++ b/src/extension/reaper_extension.cpp
@@ -2530,9 +2530,15 @@ void ReaperExtension::MonitorAutoRecordLoop() {
     auto last_warning_event_at = std::chrono::steady_clock::time_point{};
     auto last_record_led_step_at = std::chrono::steady_clock::time_point{};
     size_t record_led_step = 0;
+    auto next_soundcheck_probe_at = std::chrono::steady_clock::time_point{};
+    bool soundcheck_mode_active = soundcheck_mode_enabled_.load();
 
     while (auto_record_monitor_running_) {
         const auto now = std::chrono::steady_clock::now();
+        if (now >= next_soundcheck_probe_at) {
+            soundcheck_mode_active = RefreshSoundcheckModeFromWing();
+            next_soundcheck_probe_at = now + std::chrono::milliseconds(1000);
+        }
         const long long now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                                      now.time_since_epoch())
                                      .count();
@@ -2558,8 +2564,8 @@ void ReaperExtension::MonitorAutoRecordLoop() {
             continue;
         }
 
-        // Playback should suppress warning mode entirely.
-        if (is_playing && !is_recording) {
+        // Playback and virtual soundcheck mode should suppress warning mode entirely.
+        if ((is_playing && !is_recording) || (soundcheck_mode_active && !is_recording)) {
             above_since = {};
             below_since = {};
             if (warning_flash_running_) {
@@ -2682,6 +2688,58 @@ void ReaperExtension::MonitorAutoRecordLoop() {
 
         std::this_thread::sleep_for(poll_interval);
     }
+}
+
+bool ReaperExtension::RefreshSoundcheckModeFromWing() {
+    if (!connected_ || !osc_handler_) {
+        return soundcheck_mode_enabled_.load();
+    }
+
+    const auto channel_numbers = GetManagedMonitorChannelNumbers();
+    if (channel_numbers.empty()) {
+        return soundcheck_mode_enabled_.load();
+    }
+
+    std::vector<std::string> alt_enabled_paths;
+    std::vector<std::string> alt_group_paths;
+    alt_enabled_paths.reserve(channel_numbers.size());
+    alt_group_paths.reserve(channel_numbers.size());
+    for (int channel_number : channel_numbers) {
+        const std::string ch = std::to_string(channel_number);
+        alt_enabled_paths.push_back("/ch/" + ch + "/in/set/altsrc");
+        alt_group_paths.push_back("/ch/" + ch + "/in/conn/altgrp");
+    }
+
+    const auto alt_enabled = osc_handler_->QueryIntAddressesDirect(alt_enabled_paths, 150, 30);
+    const auto alt_groups = osc_handler_->QueryStringAddressesDirect(alt_group_paths, 150, 30);
+
+    const bool card_mode = (config_.soundcheck_output_mode == "CARD");
+    bool detected_soundcheck_mode = false;
+    for (size_t i = 0; i < channel_numbers.size(); ++i) {
+        const std::string& enabled_path = alt_enabled_paths[i];
+        const std::string& group_path = alt_group_paths[i];
+        auto enabled_it = alt_enabled.find(enabled_path);
+        if (enabled_it == alt_enabled.end() || enabled_it->second == 0) {
+            continue;
+        }
+
+        auto group_it = alt_groups.find(group_path);
+        const std::string group = (group_it != alt_groups.end()) ? group_it->second : std::string();
+        const bool group_matches = card_mode
+            ? (group == "CARD" || group == "CRD")
+            : (group == "USB");
+        if (group_matches) {
+            detected_soundcheck_mode = true;
+            break;
+        }
+    }
+
+    const bool previous = soundcheck_mode_enabled_.exchange(detected_soundcheck_mode);
+    if (previous != detected_soundcheck_mode) {
+        Log(std::string("AUDIOLAB.wing.reaper.virtualsoundcheck: Soundcheck mode state synchronized from WING: ") +
+            (detected_soundcheck_mode ? "ENABLED\n" : "DISABLED\n"));
+    }
+    return detected_soundcheck_mode;
 }
 
 void ReaperExtension::SetWarningLayerState() {


### PR DESCRIPTION
### Motivation

- Prevent auto-trigger from firing when virtual soundcheck (ALT sources) is active, since mic signals from PA/playback can retrigger warning/record logic.
- Ensure the plugin respects soundcheck mode toggles performed on the WING itself by discovering/syncing desk-side state rather than relying only on the local UI toggle.

### Description

- Added `RefreshSoundcheckModeFromWing()` to `ReaperExtension` to probe managed channel `/ch/{N}/in/set/altsrc` and `/ch/{N}/in/conn/altgrp` and detect whether desk-side soundcheck (ALT) is active, then synchronize `soundcheck_mode_enabled_` and log transitions. (files: `src/extension/reaper_extension.cpp`, `include/wingconnector/reaper_extension.h`).
- Integrated periodic WING-side probing into the auto-trigger loop by calling `RefreshSoundcheckModeFromWing()` from `MonitorAutoRecordLoop()` on a 1s cadence and keeping a local `soundcheck_mode_active` flag. (file: `src/extension/reaper_extension.cpp`).
- Suppress auto-trigger monitoring while soundcheck mode is active and REAPER is not recording, by extending the playback-suppression condition to also check `soundcheck_mode_active` so warning/record triggers are blocked during virtual soundcheck. (file: `src/extension/reaper_extension.cpp`).
- Updated documentation to describe the safety behavior: `docs/CC_BUTTONS_AND_AUTO_TRIGGER.md` and `docs/USER_GUIDE.md` now note that auto-trigger is suppressed while virtual soundcheck is active and that the state is synced from WING.

### Testing

- Attempted an automated build with `./build.sh`, which could not complete in this environment due to missing REAPER SDK headers (`lib/reaper-sdk/reaper_plugin.h` and `reaper_plugin_functions.h`), so no binary was produced.
- No additional automated tests exist in the repository; change is limited to monitoring/sync logic and documentation updates and is intended to be validated by a full build + runtime testing against a live WING console.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8eaf55f48832ba6b61972dccb18d3)