### PR TITLE
Improve Windows and macOS dialog responsiveness

### DIFF
--- a/include/wingconnector/reaper_extension.h
+++ b/include/wingconnector/reaper_extension.h
@@ -194,6 +194,7 @@ private:
     void SendBridgeMidiMessage(int status, int data1, int data2) const;
     bool BridgeMessageNeedsRelease() const;
     void InvalidateAvailableSourcesCache();
+    void InvalidateValidationCache();
     std::vector<SourceSelectionInfo> QueryAvailableSourcesSnapshot();
     bool SetupSoundcheckInternal(const std::vector<SourceSelectionInfo>& channels,
                                  const std::vector<PlaybackAllocation>* requested_allocations,
@@ -253,6 +254,12 @@ private:
     std::vector<SourceSelectionInfo> available_sources_cache_;
     std::string available_sources_cache_ip_;
     long long available_sources_cache_until_ms_{0};
+    mutable std::mutex validation_cache_mutex_;
+    ValidationState validation_cache_state_{ValidationState::NotReady};
+    std::string validation_cache_details_;
+    std::string validation_cache_ip_;
+    std::string validation_cache_output_mode_;
+    long long validation_cache_until_ms_{0};
 };
 
 // Reaper action command IDs

--- a/include/wingconnector/reaper_extension.h
+++ b/include/wingconnector/reaper_extension.h
@@ -43,6 +43,10 @@ public:
     // Channel operations (called by dialog)
     std::vector<SourceSelectionInfo> GetAvailableSources();
     void CreateTracksFromSelection(const std::vector<SourceSelectionInfo>& channels);
+    bool PrepareSoundcheckPlan(const std::vector<SourceSelectionInfo>& channels,
+                               std::vector<SourceSelectionInfo>& prepared_channels,
+                               std::vector<PlaybackAllocation>& requested_allocations,
+                               std::string& error_detail);
     bool SetupSoundcheckFromSelection(const std::vector<SourceSelectionInfo>& channels, bool setup_soundcheck = true, bool replace_existing = true);
     bool SetupSoundcheckFromPlan(const std::vector<SourceSelectionInfo>& channels,
                                  const std::vector<PlaybackAllocation>& requested_allocations,
@@ -72,6 +76,7 @@ public:
     void RefreshTracks();
     void ShowSettings();
     void ConfigureVirtualSoundcheck();
+    bool SetSoundcheckModeEnabled(bool enable, std::string* error_detail = nullptr);
     void ToggleSoundcheckMode();
     bool IsSoundcheckModeEnabled() const { return soundcheck_mode_enabled_; }
     

--- a/include/wingconnector/reaper_extension.h
+++ b/include/wingconnector/reaper_extension.h
@@ -193,6 +193,8 @@ private:
     bool FindBridgeMapping(SourceKind kind, int source_number, BridgeMapping& mapping_out) const;
     void SendBridgeMidiMessage(int status, int data1, int data2) const;
     bool BridgeMessageNeedsRelease() const;
+    void InvalidateAvailableSourcesCache();
+    std::vector<SourceSelectionInfo> QueryAvailableSourcesSnapshot();
     bool SetupSoundcheckInternal(const std::vector<SourceSelectionInfo>& channels,
                                  const std::vector<PlaybackAllocation>* requested_allocations,
                                  const std::string* output_mode_override,
@@ -247,6 +249,10 @@ private:
     std::string pending_bridge_selection_id_;
     long long pending_bridge_selection_since_ms_{0};
     int last_bridge_midi_number_{-1};
+    mutable std::mutex available_sources_cache_mutex_;
+    std::vector<SourceSelectionInfo> available_sources_cache_;
+    std::string available_sources_cache_ip_;
+    long long available_sources_cache_until_ms_{0};
 };
 
 // Reaper action command IDs

--- a/src/extension/reaper_extension.cpp
+++ b/src/extension/reaper_extension.cpp
@@ -53,6 +53,7 @@ constexpr int kManagedSourceUnreadableWarnThreshold = 3;
 constexpr int kManagedSourceDegradedCycleThreshold = 2;
 constexpr int kSoundcheckStatePollMs = 1000;
 constexpr int kAvailableSourcesCacheMs = 1500;
+constexpr int kValidationCacheMs = 1500;
 constexpr int kReaperPlayStatePlayingBit = 1;
 constexpr int kReaperPlayStateRecordingBit = 4;
 constexpr const char* kTrackSourceIdExtKey = "P_EXT:WINGCONNECTOR_SOURCE_ID";
@@ -798,6 +799,7 @@ bool ReaperExtension::ConnectToWing() {
     status_message_ = "Connecting...";
     last_connection_failure_detail_.clear();
     InvalidateAvailableSourcesCache();
+    InvalidateValidationCache();
     
     // Wing OSC is fixed to 2223.
     config_.wing_port = 2223;
@@ -846,6 +848,7 @@ bool ReaperExtension::ConnectToWing() {
     connected_ = true;
     status_message_ = "Connected";
     last_connection_failure_detail_.clear();
+    InvalidateValidationCache();
     StartAutoRecordMonitor();
     
     // Query console info
@@ -936,6 +939,15 @@ void ReaperExtension::InvalidateAvailableSourcesCache() {
     available_sources_cache_.clear();
     available_sources_cache_ip_.clear();
     available_sources_cache_until_ms_ = 0;
+}
+
+void ReaperExtension::InvalidateValidationCache() {
+    std::lock_guard<std::mutex> lock(validation_cache_mutex_);
+    validation_cache_state_ = ValidationState::NotReady;
+    validation_cache_details_.clear();
+    validation_cache_ip_.clear();
+    validation_cache_output_mode_.clear();
+    validation_cache_until_ms_ = 0;
 }
 
 std::vector<SourceSelectionInfo> ReaperExtension::QueryAvailableSourcesSnapshot() {
@@ -1222,10 +1234,32 @@ bool ReaperExtension::CheckOutputModeAvailability(const std::string& output_mode
 }
 
 ValidationState ReaperExtension::ValidateLiveRecordingSetup(std::string& details) {
+    const long long now_ms = SteadyNowMs();
+    {
+        std::lock_guard<std::mutex> lock(validation_cache_mutex_);
+        if (validation_cache_until_ms_ > now_ms &&
+            validation_cache_ip_ == config_.wing_ip &&
+            validation_cache_output_mode_ == config_.soundcheck_output_mode &&
+            connected_) {
+            details = validation_cache_details_;
+            return validation_cache_state_;
+        }
+    }
+
     if (!connected_ || !osc_handler_) {
         details = "Not connected to Wing.";
         return ValidationState::NotReady;
     }
+
+    auto finish = [this, &details](ValidationState state) {
+        std::lock_guard<std::mutex> lock(validation_cache_mutex_);
+        validation_cache_state_ = state;
+        validation_cache_details_ = details;
+        validation_cache_ip_ = config_.wing_ip;
+        validation_cache_output_mode_ = config_.soundcheck_output_mode;
+        validation_cache_until_ms_ = SteadyNowMs() + kValidationCacheMs;
+        return state;
+    };
 
     // Refresh channel/ALT state from the console before validating.
     osc_handler_->QueryAllChannels(config_.channel_count);
@@ -1234,7 +1268,7 @@ ValidationState ReaperExtension::ValidateLiveRecordingSetup(std::string& details
     const auto& channel_data = osc_handler_->GetChannelData();
     if (channel_data.empty()) {
         details = "No channel data received from Wing.";
-        return ValidationState::NotReady;
+        return finish(ValidationState::NotReady);
     }
     const auto effective_display_states = BuildManagedEffectiveDisplayStates(BuildChannelInputStateMap(channel_data));
 
@@ -1276,12 +1310,12 @@ ValidationState ReaperExtension::ValidateLiveRecordingSetup(std::string& details
 
     if (routable_channels == 0) {
         details = "Wing has no routable input channels.";
-        return ValidationState::NotReady;
+        return finish(ValidationState::NotReady);
     }
 
     if (expected_track_inputs_1based.empty()) {
         details = "Wing ALT sources are not configured for " + std::string(card_mode ? "CARD" : "USB") + ".";
-        return ValidationState::NotReady;
+        return finish(ValidationState::NotReady);
     }
 
     // Validate REAPER tracks against expected I/O mapping:
@@ -1290,7 +1324,7 @@ ValidationState ReaperExtension::ValidateLiveRecordingSetup(std::string& details
     ReaProject* proj = EnumProjects(-1, nullptr, 0);
     if (!proj) {
         details = "No active REAPER project.";
-        return ValidationState::NotReady;
+        return finish(ValidationState::NotReady);
     }
 
     int matching_tracks = 0;
@@ -1391,7 +1425,7 @@ ValidationState ReaperExtension::ValidateLiveRecordingSetup(std::string& details
 
     if (matching_tracks == 0 || matched_inputs_1based.empty()) {
         details = "No REAPER tracks match Wing ALT input/hardware routing.";
-        return ValidationState::NotReady;
+        return finish(ValidationState::NotReady);
     }
 
     if (matched_inputs_1based.size() < expected_track_inputs_1based.size()) {
@@ -1400,7 +1434,7 @@ ValidationState ReaperExtension::ValidateLiveRecordingSetup(std::string& details
             << " of " << expected_track_inputs_1based.size()
             << " expected ALT-mapped input routes.";
         details = msg.str();
-        return ValidationState::NotReady;
+        return finish(ValidationState::NotReady);
     }
 
     std::vector<std::string> mode_addresses;
@@ -1466,11 +1500,11 @@ ValidationState ReaperExtension::ValidateLiveRecordingSetup(std::string& details
 
     if (!warnings.empty()) {
         details = summary.str() + ". Warning: " + warnings.front();
-        return ValidationState::Warning;
+        return finish(ValidationState::Warning);
     }
 
     details = summary.str() + ".";
-    return ValidationState::Ready;
+    return finish(ValidationState::Ready);
 }
 
 bool ReaperExtension::SetupSoundcheckFromSelection(const std::vector<SourceSelectionInfo>& channels, bool setup_soundcheck, bool replace_existing) {
@@ -1970,6 +2004,7 @@ bool ReaperExtension::SetupSoundcheckInternal(const std::vector<SourceSelectionI
         Log("\nSelected buses/matrices were configured for recording only.\n\n");
     }
     InvalidateAvailableSourcesCache();
+    InvalidateValidationCache();
     return true;
 }
 
@@ -2354,6 +2389,7 @@ void ReaperExtension::DisconnectFromWing() {
     }
 
     InvalidateAvailableSourcesCache();
+    InvalidateValidationCache();
     connected_ = false;
     monitoring_enabled_ = false;
     status_message_ = "Disconnected";
@@ -3699,6 +3735,7 @@ bool ReaperExtension::SetSoundcheckModeEnabled(bool enable, std::string* error_d
         Log("WINGuard: Soundcheck Mode DISABLED - Channels using primary sources\n");
         status_message_ = "Soundcheck Mode OFF";
     }
+    InvalidateValidationCache();
     return true;
 }
 

--- a/src/extension/reaper_extension.cpp
+++ b/src/extension/reaper_extension.cpp
@@ -1466,6 +1466,72 @@ bool ReaperExtension::SetupSoundcheckFromSelection(const std::vector<SourceSelec
     return SetupSoundcheckInternal(channels, nullptr, nullptr, setup_soundcheck, replace_existing);
 }
 
+bool ReaperExtension::PrepareSoundcheckPlan(const std::vector<SourceSelectionInfo>& channels,
+                                            std::vector<SourceSelectionInfo>& prepared_channels,
+                                            std::vector<PlaybackAllocation>& requested_allocations,
+                                            std::string& error_detail) {
+    prepared_channels.clear();
+    requested_allocations.clear();
+
+    if (!connected_ || !osc_handler_) {
+        error_detail = "Not connected to Wing.";
+        Log("WINGuard: Not connected\n");
+        return false;
+    }
+
+    const auto& channel_data = osc_handler_->GetChannelData();
+    for (const auto& sel : channels) {
+        if (!sel.selected) {
+            continue;
+        }
+
+        SourceSelectionInfo selected = sel;
+        if (selected.kind == SourceKind::Channel) {
+            auto it = channel_data.find(selected.source_number);
+            if (it == channel_data.end()) {
+                continue;
+            }
+            if (selected.name.empty()) {
+                selected.name = StableChannelTrackName(selected.source_number);
+            }
+        }
+        prepared_channels.push_back(selected);
+    }
+
+    if (prepared_channels.empty()) {
+        error_detail = "No sources selected.";
+        Log("WINGuard: No sources selected\n");
+        return false;
+    }
+
+    Log("Refreshing selected channel source metadata from Wing...\n");
+    for (const auto& source : prepared_channels) {
+        if (source.kind == SourceKind::Channel) {
+            osc_handler_->QueryChannel(source.source_number);
+        }
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    const auto& updated_channel_data = osc_handler_->GetChannelData();
+    for (auto& selected : prepared_channels) {
+        if (selected.kind != SourceKind::Channel) {
+            continue;
+        }
+        auto it = updated_channel_data.find(selected.source_number);
+        if (it != updated_channel_data.end()) {
+            if (!selected.stereo_intent_override) {
+                selected.stereo_linked = it->second.stereo_linked;
+            }
+            if (selected.name.empty()) {
+                selected.name = StableChannelTrackName(selected.source_number);
+            }
+        }
+    }
+
+    requested_allocations = osc_handler_->CalculatePlaybackAllocation(prepared_channels);
+    return true;
+}
+
 bool ReaperExtension::SetupSoundcheckFromPlan(const std::vector<SourceSelectionInfo>& channels,
                                               const std::vector<USBAllocation>& requested_allocations,
                                               const std::string& output_mode,
@@ -1581,32 +1647,35 @@ bool ReaperExtension::SetupSoundcheckInternal(const std::vector<SourceSelectionI
         });
     }
     
-    Log("Refreshing selected channel source metadata from Wing...\n");
-    for (const auto& source : selected_sources) {
-        if (source.kind == SourceKind::Channel) {
-            osc_handler_->QueryChannel(source.source_number);
-        }
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-    const auto& updated_channel_data = osc_handler_->GetChannelData();
-    for (auto& selected : selected_sources) {
-        if (selected.kind != SourceKind::Channel) {
-            continue;
-        }
-        auto it = updated_channel_data.find(selected.source_number);
-        if (it != updated_channel_data.end()) {
-            if (!selected.stereo_intent_override) {
-                selected.stereo_linked = it->second.stereo_linked;
+    const bool has_requested_allocations = requested_allocations && !requested_allocations->empty();
+    if (!has_requested_allocations) {
+        Log("Refreshing selected channel source metadata from Wing...\n");
+        for (const auto& source : selected_sources) {
+            if (source.kind == SourceKind::Channel) {
+                osc_handler_->QueryChannel(source.source_number);
             }
-            if (selected.name.empty()) {
-                selected.name = StableChannelTrackName(selected.source_number);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+        const auto& updated_channel_data = osc_handler_->GetChannelData();
+        for (auto& selected : selected_sources) {
+            if (selected.kind != SourceKind::Channel) {
+                continue;
+            }
+            auto it = updated_channel_data.find(selected.source_number);
+            if (it != updated_channel_data.end()) {
+                if (!selected.stereo_intent_override) {
+                    selected.stereo_linked = it->second.stereo_linked;
+                }
+                if (selected.name.empty()) {
+                    selected.name = StableChannelTrackName(selected.source_number);
+                }
             }
         }
     }
     
     std::vector<USBAllocation> allocations;
-    if (requested_allocations && !requested_allocations->empty()) {
+    if (has_requested_allocations) {
         std::map<std::string, USBAllocation> allocation_map = preserved_allocations;
         for (const auto& allocation : *requested_allocations) {
             allocation_map[SourcePersistentId(allocation.source_kind, allocation.source_number)] = allocation;
@@ -3594,28 +3663,36 @@ void ReaperExtension::ConfigureVirtualSoundcheck() {
     SetupSoundcheckFromSelection(sources, true);
 }
 
-void ReaperExtension::ToggleSoundcheckMode() {
+bool ReaperExtension::SetSoundcheckModeEnabled(bool enable, std::string* error_detail) {
     if (!connected_ || !osc_handler_) {
-        ShowMessageBox(
-            "Please connect to Wing console first",
-            "WINGuard - Soundcheck Mode",
-            0
-        );
-        return;
+        if (error_detail) {
+            *error_detail = "Please connect to Wing console first";
+        }
+        return false;
     }
-    
-    // Toggle the state
-    soundcheck_mode_enabled_ = !soundcheck_mode_enabled_;
-    
-    // Apply to all channels
-    osc_handler_->SetAllChannelsAltEnabled(soundcheck_mode_enabled_);
-    
-    if (soundcheck_mode_enabled_) {
+
+    const bool current_state = soundcheck_mode_enabled_.load();
+    if (current_state == enable) {
+        return true;
+    }
+
+    osc_handler_->SetAllChannelsAltEnabled(enable);
+    soundcheck_mode_enabled_ = enable;
+
+    if (enable) {
         Log("WINGuard: Soundcheck Mode ENABLED - Channels using USB input from REAPER\n");
         status_message_ = "Soundcheck Mode ON";
     } else {
         Log("WINGuard: Soundcheck Mode DISABLED - Channels using primary sources\n");
         status_message_ = "Soundcheck Mode OFF";
+    }
+    return true;
+}
+
+void ReaperExtension::ToggleSoundcheckMode() {
+    std::string error_detail;
+    if (!SetSoundcheckModeEnabled(!soundcheck_mode_enabled_.load(), &error_detail)) {
+        ShowMessageBox(error_detail.c_str(), "WINGuard - Soundcheck Mode", 0);
     }
 }
 

--- a/src/extension/reaper_extension.cpp
+++ b/src/extension/reaper_extension.cpp
@@ -52,6 +52,7 @@ constexpr int kManagedSourceMonitorPollMs = 900;
 constexpr int kManagedSourceUnreadableWarnThreshold = 3;
 constexpr int kManagedSourceDegradedCycleThreshold = 2;
 constexpr int kSoundcheckStatePollMs = 1000;
+constexpr int kAvailableSourcesCacheMs = 1500;
 constexpr int kReaperPlayStatePlayingBit = 1;
 constexpr int kReaperPlayStateRecordingBit = 4;
 constexpr const char* kTrackSourceIdExtKey = "P_EXT:WINGCONNECTOR_SOURCE_ID";
@@ -226,6 +227,15 @@ std::string NormalizeOutputMode(std::string output_mode) {
 bool AllocationHasError(const USBAllocation& allocation) {
     return !allocation.allocation_note.empty() &&
            allocation.allocation_note.find("ERROR") != std::string::npos;
+}
+
+bool MatchesExistingSelection(const SourceSelectionInfo& info,
+                              const std::set<std::string>& existing_source_ids,
+                              const std::set<std::string>& existing_source_names,
+                              bool has_existing_selection) {
+    return has_existing_selection &&
+           (existing_source_ids.count(SourcePersistentId(info)) > 0 ||
+            existing_source_names.count(info.name) > 0);
 }
 
 bool ReadTrackAllocation(MediaTrack* track, USBAllocation& allocation_out) {
@@ -787,6 +797,7 @@ bool ReaperExtension::ConnectToWing() {
     Log("WINGuard: Connecting to WING...\n");
     status_message_ = "Connecting...";
     last_connection_failure_detail_.clear();
+    InvalidateAvailableSourcesCache();
     
     // Wing OSC is fixed to 2223.
     config_.wing_port = 2223;
@@ -860,15 +871,7 @@ bool ReaperExtension::ConnectToWing() {
 
 // Get available recording sources with routing assigned.
 std::vector<SourceSelectionInfo> ReaperExtension::GetAvailableSources() {
-    std::vector<SourceSelectionInfo> result;
-    
-    if (!connected_ || !osc_handler_) {
-        Log("WINGuard: Not connected. Cannot query sources.\n");
-        return result;
-    }
-    
-    Log("WINGuard: Querying channel sources...\n");
-
+    const long long start_ms = SteadyNowMs();
     std::set<std::string> existing_source_ids;
     std::set<std::string> existing_source_names;
     if (track_manager_) {
@@ -894,9 +897,60 @@ std::vector<SourceSelectionInfo> ReaperExtension::GetAvailableSources() {
         existing_source_ids.insert(source_id);
     }
     const bool has_existing_selection = !existing_source_ids.empty() || !existing_source_names.empty();
-    
-    // Query all channels with retries
+    std::vector<SourceSelectionInfo> result;
+    const long long now_ms = SteadyNowMs();
+    {
+        std::lock_guard<std::mutex> lock(available_sources_cache_mutex_);
+        if (available_sources_cache_until_ms_ > now_ms &&
+            !available_sources_cache_.empty() &&
+            available_sources_cache_ip_ == config_.wing_ip) {
+            result = available_sources_cache_;
+        }
+    }
+    const bool used_cache = !result.empty();
+
+    if (result.empty()) {
+        result = QueryAvailableSourcesSnapshot();
+        if (!result.empty()) {
+            std::lock_guard<std::mutex> lock(available_sources_cache_mutex_);
+            available_sources_cache_ = result;
+            available_sources_cache_ip_ = config_.wing_ip;
+            available_sources_cache_until_ms_ = now_ms + kAvailableSourcesCacheMs;
+        }
+    }
+
+    for (auto& info : result) {
+        info.selected = MatchesExistingSelection(info, existing_source_ids, existing_source_names, has_existing_selection);
+    }
+
+    Log(std::string("WINGuard: GetAvailableSources timing — source=") +
+        (used_cache ? "cache" : "fresh") +
+        ", count=" + std::to_string(result.size()) +
+        ", total=" + std::to_string(SteadyNowMs() - start_ms) + " ms.\n");
+
+    return result;
+}
+
+void ReaperExtension::InvalidateAvailableSourcesCache() {
+    std::lock_guard<std::mutex> lock(available_sources_cache_mutex_);
+    available_sources_cache_.clear();
+    available_sources_cache_ip_.clear();
+    available_sources_cache_until_ms_ = 0;
+}
+
+std::vector<SourceSelectionInfo> ReaperExtension::QueryAvailableSourcesSnapshot() {
+    const long long start_ms = SteadyNowMs();
+    std::vector<SourceSelectionInfo> result;
+
+    if (!connected_ || !osc_handler_) {
+        Log("WINGuard: Not connected. Cannot query sources.\n");
+        return result;
+    }
+
+    Log("WINGuard: Querying channel sources...\n");
+
     const auto query_delay = std::chrono::milliseconds(kQueryResponseWaitMs);
+    long long channel_query_done_ms = start_ms;
     for (int attempt = 1; attempt <= kChannelQueryAttempts; ++attempt) {
         char attempt_msg[128];
         snprintf(attempt_msg, sizeof(attempt_msg),
@@ -906,26 +960,24 @@ std::vector<SourceSelectionInfo> ReaperExtension::GetAvailableSources() {
         osc_handler_->QueryAllChannels(config_.channel_count);
         std::this_thread::sleep_for(query_delay);
         if (!osc_handler_->GetChannelData().empty()) {
+            channel_query_done_ms = SteadyNowMs();
             break;
         }
         if (attempt < kChannelQueryAttempts) {
             Log("WINGuard: No channel data yet, retrying...\n");
         }
     }
-    
-    // Get channel data
+
     const auto& channel_data = osc_handler_->GetChannelData();
     if (channel_data.empty()) {
         Log("WINGuard: No channel data received. Check timeout settings.\n");
         return result;
     }
 
-    // Query USR routing so popup can display resolved sources (e.g. USR:25 -> A:8)
     osc_handler_->QueryUserSignalInputs(48);
+    const long long user_signal_done_ms = SteadyNowMs();
 
-    // Query source labels used by the selection popup (for name fallback).
     std::set<std::pair<std::string, int>> source_endpoints;
-    std::map<int, std::pair<std::string, int>> channel_display_sources;
     const auto effective_display_states = BuildManagedEffectiveDisplayStates(BuildChannelInputStateMap(channel_data));
 
     for (const auto& pair : channel_data) {
@@ -936,52 +988,16 @@ std::vector<SourceSelectionInfo> ReaperExtension::GetAvailableSources() {
         std::pair<std::string, int> display_source =
             ResolveDisplaySource(osc_handler_.get(), ch.primary_source_group, ch.primary_source_input);
         source_endpoints.insert(display_source);
-        channel_display_sources[ch.channel_number] = display_source;
         if (ch.stereo_linked) {
             source_endpoints.insert({display_source.first, display_source.second + 1});
         }
     }
     osc_handler_->QueryInputSourceNames(source_endpoints);
+    const long long input_name_done_ms = SteadyNowMs();
 
-    std::set<std::pair<std::string, int>> missing_channel_name_sources;
-    for (const auto& pair : channel_data) {
-        const ChannelInfo& ch = pair.second;
-        const bool has_generic_channel_name =
-            ch.name.empty() || ch.name.rfind("CH", 0) == 0 || ch.name.rfind("Channel ", 0) == 0;
-        if (!has_generic_channel_name) {
-            continue;
-        }
-        auto it = channel_display_sources.find(ch.channel_number);
-        if (it == channel_display_sources.end()) {
-            continue;
-        }
-        const auto& [grp, in] = it->second;
-        if (!osc_handler_->GetInputSourceName(grp, in).empty()) {
-            continue;
-        }
-        missing_channel_name_sources.insert({grp, in});
-    }
-    std::map<std::string, std::string> direct_channel_names;
-    if (!missing_channel_name_sources.empty()) {
-        std::vector<std::string> missing_name_addresses;
-        missing_name_addresses.reserve(missing_channel_name_sources.size());
-        for (const auto& [grp, in] : missing_channel_name_sources) {
-            missing_name_addresses.push_back("/io/in/" + grp + "/" + std::to_string(in) + "/name");
-        }
-        direct_channel_names = osc_handler_->QueryStringAddressesDirect(missing_name_addresses, 100, 15);
-    }
-    
     Log("WINGuard: Processing channel data...\n");
-    // stereo_linked is set from /io/in/{grp}/{num}/mode by the second pass in QueryAllChannels.
-    // No heuristics needed.
-    
-    // Build list of channels with sources.
-    // On Behringer Wing: stereo is SOURCE-based, not channel-based.
-    // A channel is stereo if its source is stereo. That's it - no pairing needed.
-    
     for (const auto& pair : channel_data) {
         const ChannelInfo& ch = pair.second;
-        
         if (ch.primary_source_group.empty()) {
             continue;
         }
@@ -993,17 +1009,14 @@ std::vector<SourceSelectionInfo> ReaperExtension::GetAvailableSources() {
         info.color_id = ch.color;
         info.source_group = ch.primary_source_group;
         info.source_input = ch.primary_source_input;
-        
-        // stereo if source mode was "ST" or "MS" (set by QueryChannelSourceStereo)
-        bool is_stereo = ch.stereo_linked;
-        
+
+        const bool is_stereo = ch.stereo_linked;
         const std::pair<std::string, int> raw_source = {ch.primary_source_group, ch.primary_source_input};
         const std::pair<std::string, int> display_source =
             ResolveDisplaySource(osc_handler_.get(), raw_source.first, raw_source.second);
         info.source_group = display_source.first;
         info.source_input = display_source.second;
 
-        // For stereo sources, the partner is always source_input+1 in the same group
         if (is_stereo) {
             info.partner_source_group = info.source_group;
             info.partner_source_input = info.source_input + 1;
@@ -1018,12 +1031,8 @@ std::vector<SourceSelectionInfo> ReaperExtension::GetAvailableSources() {
         }
 
         info.stereo_linked = is_stereo;
-        info.selected = has_existing_selection
-            ? (existing_source_ids.count(SourcePersistentId(info)) > 0 ||
-               existing_source_names.count(info.name) > 0)
-            : false;
+        info.selected = false;
         info.soundcheck_capable = true;
-
         result.push_back(info);
     }
 
@@ -1035,12 +1044,12 @@ std::vector<SourceSelectionInfo> ReaperExtension::GetAvailableSources() {
                                           const std::map<int, std::string>& names) {
         for (int i = 1; i <= count; ++i) {
             auto mode_it = modes.find(i);
-            std::string mode = (mode_it != modes.end()) ? mode_it->second : "";
+            const std::string mode = (mode_it != modes.end()) ? mode_it->second : "";
             if (mode.empty()) {
                 continue;
             }
             const bool is_stereo = (mode == "ST" || mode == "MS");
-            if (is_stereo && (i % 2 == 0)) {
+            if (is_stereo && (i % 2) == 0) {
                 continue;
             }
 
@@ -1051,10 +1060,7 @@ std::vector<SourceSelectionInfo> ReaperExtension::GetAvailableSources() {
             info.source_input = i;
             info.stereo_linked = is_stereo;
             info.soundcheck_capable = false;
-            info.selected = has_existing_selection
-                ? (existing_source_ids.count(SourcePersistentId(info)) > 0 ||
-                   existing_source_names.count(info.name) > 0)
-                : false;
+            info.selected = false;
 
             auto name_it = names.find(i);
             std::string name = (name_it != names.end()) ? name_it->second : "";
@@ -1117,15 +1123,20 @@ std::vector<SourceSelectionInfo> ReaperExtension::GetAvailableSources() {
     Log("WINGuard: Querying bus and matrix sources...\n");
     auto [bus_modes, bus_names] = load_record_only_metadata("$BUS", "bus", 32);
     auto [mtx_modes, mtx_names] = load_record_only_metadata("$MTX", "mtx", 16);
+    const long long record_only_done_ms = SteadyNowMs();
 
     append_record_only_sources(SourceKind::Bus, "BUS", 32, "Bus", bus_modes, bus_names);
     append_record_only_sources(SourceKind::Matrix, "MTX", 16, "Matrix", mtx_modes, mtx_names);
-    
+
     char msg[128];
-    snprintf(msg, sizeof(msg), "WINGuard: Found %d selectable sources\n",
-             (int)result.size());
+    snprintf(msg, sizeof(msg), "WINGuard: Found %d selectable sources\n", (int)result.size());
     Log(msg);
-    
+    Log("WINGuard: QueryAvailableSourcesSnapshot timing — "
+        "channels=" + std::to_string(channel_query_done_ms - start_ms) +
+        " ms, usr=" + std::to_string(user_signal_done_ms - channel_query_done_ms) +
+        " ms, names=" + std::to_string(input_name_done_ms - user_signal_done_ms) +
+        " ms, buses_mtx=" + std::to_string(record_only_done_ms - input_name_done_ms) +
+        " ms, total=" + std::to_string(record_only_done_ms - start_ms) + " ms.\n");
     return result;
 }
 
@@ -1958,6 +1969,7 @@ bool ReaperExtension::SetupSoundcheckInternal(const std::vector<SourceSelectionI
     } else {
         Log("\nSelected buses/matrices were configured for recording only.\n\n");
     }
+    InvalidateAvailableSourcesCache();
     return true;
 }
 
@@ -2340,7 +2352,8 @@ void ReaperExtension::DisconnectFromWing() {
         osc_handler_->Stop();
         osc_handler_.reset();
     }
-    
+
+    InvalidateAvailableSourcesCache();
     connected_ = false;
     monitoring_enabled_ = false;
     status_message_ = "Disconnected";

--- a/src/ui/wing_connector_dialog_macos.mm
+++ b/src/ui/wing_connector_dialog_macos.mm
@@ -14,6 +14,7 @@
 #include <sstream>
 #include <algorithm>
 #include <cmath>
+#include <chrono>
 #include <limits>
 #include <mutex>
 #include <dlfcn.h>
@@ -24,6 +25,12 @@ namespace {
 
 constexpr bool kShowBridgeTabInMainUI = false;
 constexpr NSUInteger kMaxActivityLogChars = 32000;
+
+long long CurrentSteadyTimeMs() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
 
 NSImage* LoadWingGuardHeaderImage() {
     static NSImage* image = nil;
@@ -345,6 +352,7 @@ bool ShowChannelSelectionDialog(std::vector<WingConnector::ChannelSelectionInfo>
                                 bool& setup_soundcheck,
                                 bool& overwrite_existing) {
     @autoreleasepool {
+        const long long start_ms = CurrentSteadyTimeMs();
         int numChannels = (int)channels.size();
         const CGFloat rowHeight = 24.0;
         const CGFloat panelWidth = 720.0;
@@ -503,7 +511,9 @@ bool ShowChannelSelectionDialog(std::vector<WingConnector::ChannelSelectionInfo>
         [cancelButton setAction:@selector(cancelPressed:)];
 
         [panel makeKeyAndOrderFront:nil];
+        const long long shown_ms = CurrentSteadyTimeMs();
         NSInteger result = [NSApp runModalForWindow:panel];
+        const long long finished_ms = CurrentSteadyTimeMs();
         [panel setDelegate:nil];
         [tableView setDelegate:nil];
         [tableView setDataSource:nil];
@@ -524,6 +534,11 @@ bool ShowChannelSelectionDialog(std::vector<WingConnector::ChannelSelectionInfo>
         [iconView release];
         [headerBox release];
         [contentView release];
+
+        ReaperExtension::Instance().Log(std::string("WINGuard: Source chooser timings — build/show=") +
+                                        std::to_string(shown_ms - start_ms) +
+                                        " ms, modal=" + std::to_string(finished_ms - shown_ms) +
+                                        " ms, total=" + std::to_string(finished_ms - start_ms) + " ms.\n");
         
         if (result == NSModalResponseOK) {
             // Update soundcheck mode option
@@ -4239,6 +4254,7 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
 
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         auto& extension = ReaperExtension::Instance();
+        const long long flow_start_ms = CurrentSteadyTimeMs();
 
         if (!extension.IsConnected()) {
             dispatch_async(dispatch_get_main_queue(), ^{ [blockSelf appendToLog:@"Not connected — attempting to connect automatically so sources can be loaded...\n"]; });
@@ -4269,7 +4285,14 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
         }
 
         auto channels = [blockSelf copyCachedAvailableSources];
-        if (channels.empty()) {
+        const bool using_pending_draft = hasPendingSetupDraft && !pendingSetupChannels.empty();
+        if (using_pending_draft) {
+            channels = pendingSetupChannels;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [blockSelf appendToLog:[NSString stringWithFormat:@"Reusing %d staged sources from the pending draft.\n", (int)channels.size()]];
+                [blockSelf refreshAvailableSourcesCacheIfNeeded:NO logMessage:nil];
+            });
+        } else if (channels.empty()) {
             dispatch_async(dispatch_get_main_queue(), ^{ [blockSelf appendToLog:@"Getting Wing sources for live recording setup...\n"]; });
             channels = extension.GetAvailableSources();
             if (!channels.empty()) {
@@ -4290,7 +4313,14 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
             return;
         }
 
-        if (hasPendingSetupDraft && !pendingSetupChannels.empty()) {
+        const long long sources_ready_ms = CurrentSteadyTimeMs();
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [blockSelf appendToLog:[NSString stringWithFormat:@"Chooser timings: sources ready in %lld ms (%s)\n",
+                                    sources_ready_ms - flow_start_ms,
+                                    using_pending_draft ? "pending draft" : "loaded snapshot"]];
+        });
+
+        if (!using_pending_draft && !pendingSetupChannels.empty()) {
             std::set<std::string> pendingIds;
             auto pendingSourceId = [](const WingConnector::ChannelSelectionInfo& source) {
                 const char* kind = "SRC";

--- a/src/ui/wing_connector_dialog_macos.mm
+++ b/src/ui/wing_connector_dialog_macos.mm
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <mutex>
 #include <dlfcn.h>
 
 using namespace WingConnector;
@@ -22,6 +23,7 @@ using namespace WingConnector;
 namespace {
 
 constexpr bool kShowBridgeTabInMainUI = false;
+constexpr NSUInteger kMaxActivityLogChars = 32000;
 
 NSImage* LoadWingGuardHeaderImage() {
     static NSImage* image = nil;
@@ -56,6 +58,21 @@ std::vector<WingConnector::ChannelSelectionInfo> SelectedSourcesOnly(
         }
     }
     return selected;
+}
+
+NSString* CleanLogMessage(NSString* message) {
+    if (!message) {
+        return @"";
+    }
+    NSString* cleaned = [message stringByReplacingOccurrencesOfString:@"AUDIOLAB.wing.reaper.virtualsoundcheck: "
+                                                           withString:@""];
+    cleaned = [cleaned stringByReplacingOccurrencesOfString:@"AUDIOLAB.wing.reaper.virtualsoundcheck:"
+                                                 withString:@""];
+    cleaned = [cleaned stringByReplacingOccurrencesOfString:@"WINGuard: "
+                                                 withString:@""];
+    cleaned = [cleaned stringByReplacingOccurrencesOfString:@"WINGuard:"
+                                                 withString:@""];
+    return cleaned;
 }
 
 }  // namespace
@@ -198,6 +215,126 @@ std::vector<WingConnector::ChannelSelectionInfo> SelectedSourcesOnly(
 
 @end
 
+@interface SourceSelectionCoordinator : NSObject <NSTableViewDataSource, NSTableViewDelegate>
+{
+@public
+    std::vector<WingConnector::ChannelSelectionInfo>* channels;
+    NSMutableArray* rowTitles;
+}
+- (void)toggleSelected:(id)sender;
+@end
+
+@implementation SourceSelectionCoordinator
+
+- (instancetype)init {
+    self = [super init];
+    if (!self) {
+        return nil;
+    }
+    rowTitles = [[NSMutableArray alloc] init];
+    return self;
+}
+
+- (void)dealloc {
+    [rowTitles release];
+    [super dealloc];
+}
+
+- (void)toggleSelected:(id)sender {
+    NSButton* checkbox = (NSButton*)sender;
+    if (!channels) {
+        return;
+    }
+    const NSInteger row = [checkbox tag];
+    if (row < 0 || row >= (NSInteger)channels->size()) {
+        return;
+    }
+    (*channels)[(size_t)row].selected = ([checkbox state] == NSControlStateValueOn);
+}
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView*)tableView {
+    (void)tableView;
+    return channels ? (NSInteger)channels->size() : 0;
+}
+
+- (NSView*)tableView:(NSTableView*)tableView viewForTableColumn:(NSTableColumn*)tableColumn row:(NSInteger)row {
+    if (!channels || row < 0 || row >= (NSInteger)channels->size()) {
+        return nil;
+    }
+
+    const auto& ch = (*channels)[(size_t)row];
+    NSString* identifier = [tableColumn identifier];
+
+    if ([identifier isEqualToString:@"include"]) {
+        NSButton* checkbox = [tableView makeViewWithIdentifier:@"includeCheckbox" owner:nil];
+        if (!checkbox) {
+            checkbox = [[[NSButton alloc] initWithFrame:NSMakeRect(0, 0, 24, 20)] autorelease];
+            [checkbox setButtonType:NSButtonTypeSwitch];
+            [checkbox setTitle:@""];
+            [checkbox setIdentifier:@"includeCheckbox"];
+            [checkbox setControlSize:NSControlSizeSmall];
+            [checkbox setFocusRingType:NSFocusRingTypeNone];
+            [checkbox setTarget:self];
+            [checkbox setAction:@selector(toggleSelected:)];
+        }
+        [checkbox setTag:row];
+        [checkbox setState:ch.selected ? NSControlStateValueOn : NSControlStateValueOff];
+        return checkbox;
+    }
+
+    NSTextField* label = [tableView makeViewWithIdentifier:@"sourceLabel" owner:nil];
+    if (!label) {
+        label = [[[NSTextField alloc] initWithFrame:NSMakeRect(0, 0, tableColumn.width, 20)] autorelease];
+        [label setIdentifier:@"sourceLabel"];
+        [label setEditable:NO];
+        [label setBordered:NO];
+        [label setDrawsBackground:NO];
+        [label setLineBreakMode:NSLineBreakByTruncatingTail];
+        [label setFont:[NSFont systemFontOfSize:12]];
+    }
+
+    if (row >= (NSInteger)[rowTitles count]) {
+        [label setStringValue:@""];
+        return label;
+    }
+    [label setStringValue:[rowTitles objectAtIndex:row]];
+    return label;
+}
+
+@end
+
+@interface SourceSelectionPanelCoordinator : NSObject <NSWindowDelegate>
+{
+@public
+    NSWindow* window;
+}
+- (void)confirmPressed:(id)sender;
+- (void)cancelPressed:(id)sender;
+- (void)windowWillClose:(NSNotification*)notification;
+@end
+
+@implementation SourceSelectionPanelCoordinator
+
+- (void)confirmPressed:(id)sender {
+    (void)sender;
+    [NSApp stopModalWithCode:NSModalResponseOK];
+    [window orderOut:nil];
+}
+
+- (void)cancelPressed:(id)sender {
+    (void)sender;
+    [NSApp stopModalWithCode:NSModalResponseCancel];
+    [window orderOut:nil];
+}
+
+- (void)windowWillClose:(NSNotification*)notification {
+    if ([notification object] == window) {
+        [NSApp stopModalWithCode:NSModalResponseCancel];
+    }
+}
+
+@end
+
 // ===== CHANNEL SELECTION DIALOG =====
 
 extern "C" {
@@ -208,33 +345,88 @@ bool ShowChannelSelectionDialog(std::vector<WingConnector::ChannelSelectionInfo>
                                 bool& setup_soundcheck,
                                 bool& overwrite_existing) {
     @autoreleasepool {
-        NSAlert* alert = [[NSAlert alloc] init];
-        [alert setMessageText:[NSString stringWithUTF8String:title]];
-        [alert setInformativeText:[NSString stringWithUTF8String:description]];
-        [alert setAlertStyle:NSAlertStyleInformational];
-        
-        // Calculate height needed for all channels
         int numChannels = (int)channels.size();
-        int rowHeight = 24;
-        int maxHeight = 400;
-        int scrollHeight = std::min(numChannels * rowHeight + 20, maxHeight);
-        
-        // Create scrollable view for checkboxes
-        NSScrollView* scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(0, 0, 500, scrollHeight)];
+        const CGFloat rowHeight = 24.0;
+        const CGFloat panelWidth = 720.0;
+        const CGFloat panelHeight = 620.0;
+        const CGFloat outerPadding = 20.0;
+        const CGFloat scrollHeight = 420.0;
+        const CGFloat scrollWidth = panelWidth - (outerPadding * 2.0);
+        const CGFloat contentHeight = std::max<CGFloat>(rowHeight * numChannels, scrollHeight);
+
+        NSPanel* panel = [[NSPanel alloc] initWithContentRect:NSMakeRect(0, 0, panelWidth, panelHeight)
+                                                    styleMask:(NSWindowStyleMaskTitled | NSWindowStyleMaskClosable)
+                                                      backing:NSBackingStoreBuffered
+                                                        defer:NO];
+        [panel setTitle:@"WINGuard"];
+        [panel center];
+        [panel setReleasedWhenClosed:NO];
+        [panel setMovableByWindowBackground:NO];
+
+        NSView* contentView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, panelWidth, panelHeight)];
+        [panel setContentView:contentView];
+
+        NSBox* headerBox = [[NSBox alloc] initWithFrame:NSMakeRect(0, panelHeight - 138.0, panelWidth, 138.0)];
+        [headerBox setBoxType:NSBoxCustom];
+        [headerBox setFillColor:[NSColor colorWithWhite:0.95 alpha:1.0]];
+        [headerBox setBorderWidth:0];
+        [contentView addSubview:headerBox];
+
+        NSImageView* iconView = [[NSImageView alloc] initWithFrame:NSMakeRect(outerPadding + 4.0, panelHeight - 122.0, 96.0, 96.0)];
+        [iconView setImage:LoadWingGuardHeaderImage()];
+        [iconView setImageScaling:NSImageScaleProportionallyUpOrDown];
+        [contentView addSubview:iconView];
+
+        NSTextField* titleLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(outerPadding + 118.0, panelHeight - 66.0, panelWidth - 180.0, 24.0)];
+        [titleLabel setStringValue:[NSString stringWithUTF8String:title ? title : "Choose Sources"]];
+        [titleLabel setFont:[NSFont systemFontOfSize:18 weight:NSFontWeightMedium]];
+        [titleLabel setBezeled:NO];
+        [titleLabel setEditable:NO];
+        [titleLabel setSelectable:NO];
+        [titleLabel setBackgroundColor:[NSColor clearColor]];
+        [titleLabel setTextColor:[NSColor labelColor]];
+        [contentView addSubview:titleLabel];
+
+        NSTextField* descriptionLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(outerPadding + 118.0, panelHeight - 102.0, panelWidth - 180.0, 42.0)];
+        [descriptionLabel setStringValue:[NSString stringWithUTF8String:description ? description : ""]];
+        [descriptionLabel setFont:[NSFont systemFontOfSize:12]];
+        [descriptionLabel setBezeled:NO];
+        [descriptionLabel setEditable:NO];
+        [descriptionLabel setSelectable:NO];
+        [descriptionLabel setBackgroundColor:[NSColor clearColor]];
+        [descriptionLabel setTextColor:[NSColor secondaryLabelColor]];
+        [descriptionLabel setLineBreakMode:NSLineBreakByWordWrapping];
+        [descriptionLabel setUsesSingleLineMode:NO];
+        [contentView addSubview:descriptionLabel];
+
+        NSScrollView* scrollView = [[NSScrollView alloc] initWithFrame:NSMakeRect(outerPadding, 128.0, scrollWidth, scrollHeight)];
         [scrollView setHasVerticalScroller:YES];
         [scrollView setHasHorizontalScroller:NO];
         [scrollView setBorderType:NSBezelBorder];
-        
-        // Document view to hold all checkboxes
-        NSView* documentView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 480, numChannels * rowHeight)];
-        
-        // Create checkbox array to track user selections
-        NSMutableArray* checkboxes = [NSMutableArray arrayWithCapacity:numChannels];
-        
-        // Add checkbox for each channel
-        int yPos = numChannels * rowHeight - rowHeight;
-        for (int i = 0; i < numChannels; i++) {
-            const auto& ch = channels[i];
+
+        NSTableView* tableView = [[NSTableView alloc] initWithFrame:NSMakeRect(0, 0, scrollWidth, contentHeight)];
+        [tableView setHeaderView:nil];
+        [tableView setRowHeight:rowHeight];
+        [tableView setUsesAlternatingRowBackgroundColors:YES];
+        [tableView setIntercellSpacing:NSMakeSize(0.0, 2.0)];
+        [tableView setColumnAutoresizingStyle:NSTableViewNoColumnAutoresizing];
+
+        NSTableColumn* includeColumn = [[NSTableColumn alloc] initWithIdentifier:@"include"];
+        [includeColumn setWidth:34.0];
+        [includeColumn setResizingMask:NSTableColumnNoResizing];
+        [tableView addTableColumn:includeColumn];
+        [includeColumn release];
+
+        NSTableColumn* sourceColumn = [[NSTableColumn alloc] initWithIdentifier:@"source"];
+        [sourceColumn setWidth:scrollWidth - 34.0];
+        [sourceColumn setResizingMask:NSTableColumnAutoresizingMask];
+        [tableView addTableColumn:sourceColumn];
+        [sourceColumn release];
+
+        SourceSelectionCoordinator* coordinator = [[SourceSelectionCoordinator alloc] init];
+        coordinator->channels = &channels;
+        [coordinator->rowTitles removeAllObjects];
+        for (const auto& ch : channels) {
             NSString* kindLabel = @"SRC";
             switch (ch.kind) {
                 case SourceKind::Channel: kindLabel = @"CH"; break;
@@ -242,11 +434,11 @@ bool ShowChannelSelectionDialog(std::vector<WingConnector::ChannelSelectionInfo>
                 case SourceKind::Main: kindLabel = @"MAIN"; break;
                 case SourceKind::Matrix: kindLabel = @"MTX"; break;
             }
+
             const std::string display_name = ch.name.empty()
                 ? (std::string([kindLabel UTF8String]) + " " + std::to_string(ch.source_number))
                 : ch.name;
-            
-            // Create title showing channel info
+
             NSString* title = nil;
             if (ch.stereo_linked && !ch.partner_source_group.empty()) {
                 title = [NSString stringWithFormat:@"%@%02d  %s  [%s%d / %s%d]%s",
@@ -268,68 +460,83 @@ bool ShowChannelSelectionDialog(std::vector<WingConnector::ChannelSelectionInfo>
                          ch.stereo_linked ? " [Stereo]" : "",
                          ch.soundcheck_capable ? "" : " [Record only]"];
             }
-            
-            NSButton* checkbox = [[NSButton alloc] initWithFrame:NSMakeRect(10, yPos, 460, 20)];
-            [checkbox setButtonType:NSButtonTypeSwitch];
-            [checkbox setTitle:title];
-            [checkbox setState:ch.selected ? NSControlStateValueOn : NSControlStateValueOff];
-            
-            [documentView addSubview:checkbox];
-            [checkboxes addObject:checkbox];
-            
-            yPos -= rowHeight;
+            [coordinator->rowTitles addObject:title ? title : @""];
         }
-        
-        [scrollView setDocumentView:documentView];
-        NSClipView* clipView = [scrollView contentView];
-        NSRect clipBounds = [clipView bounds];
-        NSRect documentBounds = [documentView bounds];
-        CGFloat topOffset = std::max<CGFloat>(0.0, NSMaxY(documentBounds) - NSHeight(clipBounds));
-        [clipView scrollToPoint:NSMakePoint(0, topOffset)];
-        [scrollView reflectScrolledClipView:clipView];
-        
-        // Create container view for scroll view + options
-        NSView* containerView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 500, scrollHeight + 70)];
-        
-        // Position scroll view at top of container
-        [scrollView setFrameOrigin:NSMakePoint(0, 70)];
-        [containerView addSubview:scrollView];
-        
-        // Add soundcheck mode checkbox at bottom
-        NSButton* overwriteCheckbox = [[NSButton alloc] initWithFrame:NSMakeRect(10, 36, 480, 20)];
+        [tableView setDataSource:coordinator];
+        [tableView setDelegate:coordinator];
+        [tableView reloadData];
+        [scrollView setDocumentView:tableView];
+        if (numChannels > 0) {
+            [tableView scrollRowToVisible:0];
+        }
+        [contentView addSubview:scrollView];
+
+        NSButton* overwriteCheckbox = [[NSButton alloc] initWithFrame:NSMakeRect(outerPadding, 86.0, scrollWidth, 20)];
         [overwriteCheckbox setButtonType:NSButtonTypeSwitch];
         [overwriteCheckbox setTitle:@"Replace all existing REAPER tracks when applying this source selection"];
         [overwriteCheckbox setState:overwrite_existing ? NSControlStateValueOn : NSControlStateValueOff];
-        [containerView addSubview:overwriteCheckbox];
+        [contentView addSubview:overwriteCheckbox];
 
-        NSButton* soundcheckCheckbox = [[NSButton alloc] initWithFrame:NSMakeRect(10, 10, 480, 20)];
+        NSButton* soundcheckCheckbox = [[NSButton alloc] initWithFrame:NSMakeRect(outerPadding, 58.0, scrollWidth, 20)];
         [soundcheckCheckbox setButtonType:NSButtonTypeSwitch];
         [soundcheckCheckbox setTitle:@"Configure soundcheck mode for selected channels only (ALT + REAPER playback inputs)"];
         [soundcheckCheckbox setState:setup_soundcheck ? NSControlStateValueOn : NSControlStateValueOff];
-        [containerView addSubview:soundcheckCheckbox];
+        [contentView addSubview:soundcheckCheckbox];
+
+        NSButton* cancelButton = [[NSButton alloc] initWithFrame:NSMakeRect(panelWidth - outerPadding - 208.0, 16.0, 96.0, 28.0)];
+        [cancelButton setTitle:@"Cancel"];
+        [cancelButton setBezelStyle:NSBezelStyleRounded];
+        [contentView addSubview:cancelButton];
+
+        NSButton* okButton = [[NSButton alloc] initWithFrame:NSMakeRect(panelWidth - outerPadding - 104.0, 16.0, 88.0, 28.0)];
+        [okButton setTitle:@"OK"];
+        [okButton setBezelStyle:NSBezelStyleRounded];
+        [okButton setKeyEquivalent:@"\r"];
+        [contentView addSubview:okButton];
+
+        SourceSelectionPanelCoordinator* panelCoordinator = [[SourceSelectionPanelCoordinator alloc] init];
+        panelCoordinator->window = panel;
+        [panel setDelegate:panelCoordinator];
+        [okButton setTarget:panelCoordinator];
+        [okButton setAction:@selector(confirmPressed:)];
+        [cancelButton setTarget:panelCoordinator];
+        [cancelButton setAction:@selector(cancelPressed:)];
+
+        [panel makeKeyAndOrderFront:nil];
+        NSInteger result = [NSApp runModalForWindow:panel];
+        [panel setDelegate:nil];
+        [tableView setDelegate:nil];
+        [tableView setDataSource:nil];
+
+        const BOOL selectedSoundcheck = ([soundcheckCheckbox state] == NSControlStateValueOn);
+        const BOOL selectedOverwrite = ([overwriteCheckbox state] == NSControlStateValueOn);
+
+        [panelCoordinator release];
+        [coordinator release];
+        [tableView release];
+        [scrollView release];
+        [overwriteCheckbox release];
+        [soundcheckCheckbox release];
+        [okButton release];
+        [cancelButton release];
+        [descriptionLabel release];
+        [titleLabel release];
+        [iconView release];
+        [headerBox release];
+        [contentView release];
         
-        [alert setAccessoryView:containerView];
-        
-        // Add buttons
-        [alert addButtonWithTitle:@"OK"];
-        [alert addButtonWithTitle:@"Cancel"];
-        
-        // Show dialog
-        NSInteger result = [alert runModal];
-        
-        if (result == NSAlertFirstButtonReturn) {
-            // OK clicked - update selection states
-            for (int i = 0; i < numChannels; i++) {
-                NSButton* checkbox = [checkboxes objectAtIndex:i];
-                channels[i].selected = ([checkbox state] == NSControlStateValueOn);
-            }
+        if (result == NSModalResponseOK) {
             // Update soundcheck mode option
-            setup_soundcheck = ([soundcheckCheckbox state] == NSControlStateValueOn);
-            overwrite_existing = ([overwriteCheckbox state] == NSControlStateValueOn);
+            setup_soundcheck = selectedSoundcheck ? true : false;
+            overwrite_existing = selectedOverwrite ? true : false;
+            [panel close];
+            [panel release];
             return true;
         }
         
         // Cancel clicked
+        [panel close];
+        [panel release];
         return false;
     }
 }
@@ -798,6 +1005,12 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
     std::string latestLiveSetupValidationDetails;
     ValidationState latestMidiValidationState;
     std::string latestMidiValidationDetails;
+    std::mutex activityLogMutex;
+    std::string pendingActivityLog;
+    std::mutex availableSourcesMutex;
+    std::vector<WingConnector::ChannelSelectionInfo> cachedAvailableSources;
+    BOOL availableSourcesLoaded;
+    BOOL availableSourcesRefreshInProgress;
 }
 
 - (instancetype)init;
@@ -824,6 +1037,13 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
 - (void)adjustWindowHeightToFitContent;
 - (void)updateFormLayoutForCurrentWindowSize;
 - (void)appendToLog:(NSString*)message;
+- (void)appendCleanedLogToView:(NSString*)message;
+- (void)enqueueLogMessageUtf8:(const std::string&)message;
+- (void)flushPendingLogBuffer;
+- (void)clearAvailableSourcesCache;
+- (std::vector<WingConnector::ChannelSelectionInfo>)copyCachedAvailableSources;
+- (void)storeCachedAvailableSources:(const std::vector<WingConnector::ChannelSelectionInfo>&)sources;
+- (void)refreshAvailableSourcesCacheIfNeeded:(BOOL)force logMessage:(NSString*)logMessage;
 - (void)setWorkingState:(BOOL)working;
 - (void)onDebugLogToggled:(id)sender;
 - (void)windowDidResize:(NSNotification*)notification;
@@ -921,6 +1141,8 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
     latestMidiValidationDetails = ReaperExtension::Instance().IsMidiActionsEnabled()
         ? "MIDI shortcuts are enabled, but their WING button mapping has not been checked yet."
         : "MIDI shortcuts are disabled.";
+    availableSourcesLoaded = NO;
+    availableSourcesRefreshInProgress = NO;
     meterPreviewTimer = nil;
     collapsedContentHeight = 780.0;
     expandedContentHeight = 780.0;
@@ -929,12 +1151,10 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
     [self setupUI];
     [self updateConnectionStatus];
     
-    // Set up log callback to capture C++ Log() calls
+    // Buffer C++ log messages and flush them on the UI timer instead of
+    // dispatching every line to the main queue immediately.
     auto log_lambda = [self](const std::string& msg) {
-        NSString* nsMsg = [NSString stringWithUTF8String:msg.c_str()];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self appendToLog:nsMsg];
-        });
+        [self enqueueLogMessageUtf8:msg];
     };
     ReaperExtension::Instance().SetLogCallback(log_lambda);
     
@@ -952,6 +1172,8 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
 }
 
 - (void)dealloc {
+    ReaperExtension::Instance().SetLogCallback({});
+    [self flushPendingLogBuffer];
     [discoveredIPs release];
     // Release UI elements that we retain in instance variables
     [wingDropdown release];
@@ -2808,16 +3030,20 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
 
 - (void)refreshMonitorTrackDropdown {
     auto& config = ReaperExtension::Instance().GetConfig();
-    [monitorTrackDropdown removeAllItems];
-
-    [monitorTrackDropdown addItemWithTitle:@"Auto (Armed+Monitored)"];
-    [[monitorTrackDropdown itemAtIndex:0] setTag:0];
-
     const int track_count = ReaperExtension::Instance().GetProjectTrackCount();
-    for (int i = 1; i <= track_count; ++i) {
-        NSString* title = [NSString stringWithFormat:@"Track %d", i];
-        [monitorTrackDropdown addItemWithTitle:title];
-        [[monitorTrackDropdown itemAtIndex:i] setTag:i];
+    const NSInteger expected_item_count = track_count + 1;
+
+    if ([monitorTrackDropdown numberOfItems] != expected_item_count) {
+        [monitorTrackDropdown removeAllItems];
+
+        [monitorTrackDropdown addItemWithTitle:@"Auto (Armed+Monitored)"];
+        [[monitorTrackDropdown itemAtIndex:0] setTag:0];
+
+        for (int i = 1; i <= track_count; ++i) {
+            NSString* title = [NSString stringWithFormat:@"Track %d", i];
+            [monitorTrackDropdown addItemWithTitle:title];
+            [[monitorTrackDropdown itemAtIndex:i] setTag:i];
+        }
     }
 
     int wanted = std::max(0, config.auto_record_monitor_track);
@@ -2825,7 +3051,11 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
         wanted = 0;
         config.auto_record_monitor_track = 0;
     }
-    [monitorTrackDropdown selectItemAtIndex:wanted];
+
+    NSMenuItem* selected_item = [monitorTrackDropdown selectedItem];
+    if (!selected_item || [selected_item tag] != wanted) {
+        [monitorTrackDropdown selectItemAtIndex:wanted];
+    }
 }
 
 - (void)onMonitorTrackChanged:(id)sender {
@@ -3000,21 +3230,112 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
     if (!message) {
         return;
     }
-    NSString* cleaned = [message stringByReplacingOccurrencesOfString:@"AUDIOLAB.wing.reaper.virtualsoundcheck: "
-                                                           withString:@""];
-    cleaned = [cleaned stringByReplacingOccurrencesOfString:@"AUDIOLAB.wing.reaper.virtualsoundcheck:"
-                                                 withString:@""];
-    cleaned = [cleaned stringByReplacingOccurrencesOfString:@"WINGuard: "
-                                                 withString:@""];
-    cleaned = [cleaned stringByReplacingOccurrencesOfString:@"WINGuard:"
-                                                 withString:@""];
-    NSString* currentText = [activityLogView string];
-    NSString* newText = [currentText stringByAppendingString:cleaned];
-    [activityLogView setString:newText];
-    
-    // Scroll to bottom
-    NSRange range = NSMakeRange([[activityLogView string] length], 0);
+    [self appendCleanedLogToView:CleanLogMessage(message)];
+}
+
+- (void)appendCleanedLogToView:(NSString*)message {
+    if (!activityLogView || !message || [message length] == 0) {
+        return;
+    }
+
+    NSTextStorage* storage = [activityLogView textStorage];
+    if (!storage) {
+        return;
+    }
+
+    [[storage mutableString] appendString:message];
+    const NSUInteger length = [[storage string] length];
+    if (length > kMaxActivityLogChars) {
+        [[storage mutableString] deleteCharactersInRange:NSMakeRange(0, length - kMaxActivityLogChars)];
+    }
+
+    NSRange range = NSMakeRange([[storage string] length], 0);
     [activityLogView scrollRangeToVisible:range];
+}
+
+- (void)enqueueLogMessageUtf8:(const std::string&)message {
+    std::lock_guard<std::mutex> lock(activityLogMutex);
+    pendingActivityLog += message;
+    if (pendingActivityLog.empty() || pendingActivityLog.back() != '\n') {
+        pendingActivityLog += '\n';
+    }
+}
+
+- (void)flushPendingLogBuffer {
+    std::string chunk;
+    {
+        std::lock_guard<std::mutex> lock(activityLogMutex);
+        if (pendingActivityLog.empty()) {
+            return;
+        }
+        chunk.swap(pendingActivityLog);
+    }
+
+    NSString* raw = [NSString stringWithUTF8String:chunk.c_str()];
+    if (!raw) {
+        raw = @"";
+    }
+    [self appendCleanedLogToView:CleanLogMessage(raw)];
+}
+
+- (void)clearAvailableSourcesCache {
+    std::lock_guard<std::mutex> lock(availableSourcesMutex);
+    cachedAvailableSources.clear();
+    availableSourcesLoaded = NO;
+    availableSourcesRefreshInProgress = NO;
+}
+
+- (std::vector<WingConnector::ChannelSelectionInfo>)copyCachedAvailableSources {
+    std::lock_guard<std::mutex> lock(availableSourcesMutex);
+    return cachedAvailableSources;
+}
+
+- (void)storeCachedAvailableSources:(const std::vector<WingConnector::ChannelSelectionInfo>&)sources {
+    std::lock_guard<std::mutex> lock(availableSourcesMutex);
+    cachedAvailableSources = sources;
+    availableSourcesLoaded = !sources.empty();
+}
+
+- (void)refreshAvailableSourcesCacheIfNeeded:(BOOL)force logMessage:(NSString*)logMessage {
+    auto& extension = ReaperExtension::Instance();
+    if (!extension.IsConnected()) {
+        [self clearAvailableSourcesCache];
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(availableSourcesMutex);
+        if (availableSourcesRefreshInProgress) {
+            return;
+        }
+        if (!force && availableSourcesLoaded) {
+            return;
+        }
+        availableSourcesRefreshInProgress = YES;
+    }
+
+    WingConnectorWindowController* blockSelf = self;
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        if (logMessage) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [blockSelf appendToLog:logMessage];
+            });
+        }
+
+        auto loaded_sources = extension.GetAvailableSources();
+        {
+            std::lock_guard<std::mutex> lock(blockSelf->availableSourcesMutex);
+            blockSelf->cachedAvailableSources = loaded_sources;
+            blockSelf->availableSourcesLoaded = !loaded_sources.empty();
+            blockSelf->availableSourcesRefreshInProgress = NO;
+        }
+
+        if (loaded_sources.empty()) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [blockSelf appendToLog:@"Source cache refresh completed with no selectable sources.\n"];
+            });
+        }
+    });
 }
 
 // ===== WING DISCOVERY =====
@@ -3101,6 +3422,7 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
     if (discoveredIPs && idx >= 0 && idx < (NSInteger)[discoveredIPs count]) {
         auto& config = ReaperExtension::Instance().GetConfig();
         config.wing_ip = std::string([[discoveredIPs objectAtIndex:idx] UTF8String]);
+        [self clearAvailableSourcesCache];
         [manualIPField setStringValue:[discoveredIPs objectAtIndex:idx]];
         [self appendToLog:[NSString stringWithFormat:@"Selected Wing: %@\n",
                           [wingDropdown titleOfSelectedItem]]];
@@ -3125,6 +3447,7 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
         if (extension.IsConnected()) {
             extension.DisconnectFromWing();
             dispatch_async(dispatch_get_main_queue(), ^{
+                [blockSelf clearAvailableSourcesCache];
                 blockSelf->liveSetupValidated = NO;
                 [blockSelf appendToLog:@"Disconnected from Wing.\n"];
                 [blockSelf setWorkingState:NO];
@@ -3160,6 +3483,8 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
         dispatch_async(dispatch_get_main_queue(), ^{
             [blockSelf appendToLog:[NSString stringWithFormat:@"✓ Connected to %s\n",
                                     config.wing_ip.c_str()]];
+            [blockSelf refreshAvailableSourcesCacheIfNeeded:YES
+                                                 logMessage:@"Refreshing selectable sources in the background...\n"];
             [blockSelf setWorkingState:NO];
             [blockSelf updateConnectionStatus];
         });
@@ -3201,6 +3526,7 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
         stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     auto& config = ReaperExtension::Instance().GetConfig();
     config.wing_ip = ([typed length] > 0) ? std::string([typed UTF8String]) : std::string();
+    [self clearAvailableSourcesCache];
     if ([typed length] > 0) {
         [self appendToLog:[NSString stringWithFormat:@"Manual Wing IP set to %@\n", typed]];
     }
@@ -3278,7 +3604,10 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
     if (pendingSetupChannels.empty() && extension.IsConnected()) {
         WingConnectorWindowController* blockSelf = self;
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            auto loaded_sources = extension.GetAvailableSources();
+            auto loaded_sources = [blockSelf copyCachedAvailableSources];
+            if (loaded_sources.empty()) {
+                loaded_sources = extension.GetAvailableSources();
+            }
             int selectedCount = 0;
             for (const auto& source : loaded_sources) {
                 if (source.selected) {
@@ -3290,6 +3619,7 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
                     return;
                 }
                 if (!loaded_sources.empty() && selectedCount > 0) {
+                    [blockSelf storeCachedAvailableSources:loaded_sources];
                     blockSelf->pendingSetupChannels = loaded_sources;
                     blockSelf->pendingSetupUsesExistingSelection = NO;
                     [blockSelf appendToLog:[NSString stringWithFormat:@"Loaded %d currently selected sources into the pending draft for %s mode.\n",
@@ -3891,6 +4221,7 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
 
 - (void)onMeterPreviewTimer:(NSTimer*)timer {
     (void)timer;
+    [self flushPendingLogBuffer];
     auto& extension = ReaperExtension::Instance();
     [self refreshBridgeStatus];
     double lin = extension.ReadCurrentTriggerLevel();
@@ -3931,12 +4262,25 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
             }
             dispatch_async(dispatch_get_main_queue(), ^{
                 [blockSelf appendToLog:@"✓ Auto-connected to Wing for source staging\n"];
+                [blockSelf refreshAvailableSourcesCacheIfNeeded:YES
+                                                     logMessage:@"Refreshing selectable sources in the background...\n"];
                 [blockSelf updateConnectionStatus];
             });
         }
 
-        dispatch_async(dispatch_get_main_queue(), ^{ [blockSelf appendToLog:@"Getting Wing sources for live recording setup...\n"]; });
-        auto channels = extension.GetAvailableSources();
+        auto channels = [blockSelf copyCachedAvailableSources];
+        if (channels.empty()) {
+            dispatch_async(dispatch_get_main_queue(), ^{ [blockSelf appendToLog:@"Getting Wing sources for live recording setup...\n"]; });
+            channels = extension.GetAvailableSources();
+            if (!channels.empty()) {
+                [blockSelf storeCachedAvailableSources:channels];
+            }
+        } else {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [blockSelf appendToLog:[NSString stringWithFormat:@"Using %d cached selectable sources.\n", (int)channels.size()]];
+                [blockSelf refreshAvailableSourcesCacheIfNeeded:NO logMessage:nil];
+            });
+        }
         
         if (channels.empty()) {
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -4062,6 +4406,8 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
         }
 
         std::vector<WingConnector::ChannelSelectionInfo> channels_to_apply;
+        std::vector<WingConnector::ChannelSelectionInfo> prepared_channels;
+        std::vector<WingConnector::PlaybackAllocation> prepared_allocations;
         bool setup_soundcheck = blockSelf->pendingSetupSoundcheck ? true : false;
         bool overwrite_existing = blockSelf->pendingReplaceExisting ? true : false;
 
@@ -4107,17 +4453,37 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
             return;
         }
 
+        std::string plan_error;
+        if (!extension.PrepareSoundcheckPlan(channels_to_apply, prepared_channels, prepared_allocations, plan_error)) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                NSString* detail = plan_error.empty()
+                    ? @"Could not prepare the live setup plan."
+                    : [NSString stringWithUTF8String:plan_error.c_str()];
+                [blockSelf appendToLog:[NSString stringWithFormat:@"✗ %s\n", [detail UTF8String]]];
+                [blockSelf setWorkingState:NO];
+            });
+            return;
+        }
+
         extension.GetConfig().soundcheck_output_mode = blockSelf->pendingOutputMode;
         dispatch_async(dispatch_get_main_queue(), ^{
             [blockSelf appendToLog:[NSString stringWithFormat:@"Applying live recording setup for %d sources (%s existing REAPER tracks, %s mode)...\n",
                                     selectedCount,
                                     overwrite_existing ? "replacing" : "appending to",
                                     blockSelf->pendingOutputMode.c_str()]];
-            extension.SetupSoundcheckFromSelection(channels_to_apply, setup_soundcheck, overwrite_existing);
-            [blockSelf appendToLog:@"✓ Live recording setup complete\n"];
-            [blockSelf clearPendingSetupDraft:NO];
-            [blockSelf refreshMonitorTrackDropdown];
-            [blockSelf persistConfigAndLog:@"Saved live setup changes.\n"];
+            const bool success = extension.SetupSoundcheckFromPlan(prepared_channels,
+                                                                   prepared_allocations,
+                                                                   blockSelf->pendingOutputMode,
+                                                                   setup_soundcheck,
+                                                                   overwrite_existing);
+            if (success) {
+                [blockSelf appendToLog:@"✓ Live recording setup complete\n"];
+                [blockSelf clearPendingSetupDraft:NO];
+                [blockSelf refreshMonitorTrackDropdown];
+                [blockSelf persistConfigAndLog:@"Saved live setup changes.\n"];
+            } else {
+                [blockSelf appendToLog:@"✗ Live recording setup did not complete\n"];
+            }
             [blockSelf setWorkingState:NO];
             [blockSelf refreshLiveSetupValidation];
         });
@@ -4158,13 +4524,25 @@ bool ShowExistingProjectAdoptionEditor(const std::vector<AdoptionEditorRow>& row
             });
         }
 
-        // CRITICAL: ToggleSoundcheckMode() shows message boxes, which MUST run on main thread
         dispatch_async(dispatch_get_main_queue(), ^{
             [blockSelf appendToLog:@"Toggling soundcheck mode...\n"];
-            
-            extension.ToggleSoundcheckMode();
-            bool enabled = extension.IsSoundcheckModeEnabled();
-            
+        });
+
+        const bool enabled = !extension.IsSoundcheckModeEnabled();
+        std::string error_detail;
+        if (!extension.SetSoundcheckModeEnabled(enabled, &error_detail)) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                NSString* detail = error_detail.empty()
+                    ? @"Could not change soundcheck mode."
+                    : [NSString stringWithUTF8String:error_detail.c_str()];
+                [blockSelf appendToLog:[NSString stringWithFormat:@"✗ %s\n", [detail UTF8String]]];
+                [blockSelf setWorkingState:NO];
+                [blockSelf updateConnectionStatus];
+            });
+            return;
+        }
+
+        dispatch_async(dispatch_get_main_queue(), ^{
             if (enabled) {
                 [blockSelf appendToLog:@"✓ Soundcheck mode ENABLED (using playback inputs)\n"];
             } else {

--- a/src/ui/wing_connector_dialog_windows.cpp
+++ b/src/ui/wing_connector_dialog_windows.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <set>
 #include <string>
+#include <thread>
 #include <mutex>
 #include <utility>
 #include <vector>
@@ -47,8 +48,55 @@ constexpr int kMinWindowWidth = 1180;
 constexpr int kMinWindowHeight = 860;
 constexpr UINT_PTR kRefreshTimerId = 101;
 constexpr UINT kRefreshTimerMs = 500;
+constexpr UINT kMsgAsyncScanComplete = WM_APP + 1;
+constexpr UINT kMsgAsyncConnectComplete = WM_APP + 2;
+constexpr UINT kMsgAsyncSourcesComplete = WM_APP + 3;
+constexpr UINT kMsgAsyncApplyPlanComplete = WM_APP + 4;
+constexpr UINT kMsgAsyncToggleComplete = WM_APP + 5;
+constexpr UINT kMsgAsyncValidationComplete = WM_APP + 6;
 constexpr int kScrollLineStep = 36;
 constexpr unsigned long kValidationRefreshIntervalMs = 1500;
+
+struct AsyncScanResult {
+    std::vector<WingInfo> wings;
+    bool show_feedback = true;
+};
+
+struct AsyncConnectResult {
+    bool success = false;
+    std::string ip;
+    std::string failure_detail;
+    std::wstring success_footer;
+};
+
+struct AsyncSourcesResult {
+    bool success = false;
+    bool used_pending_draft = false;
+    std::vector<SourceSelectionInfo> channels;
+    std::string failure_detail;
+};
+
+struct AsyncApplyPlanResult {
+    bool success = false;
+    bool setup_soundcheck = true;
+    bool replace_existing = true;
+    std::string output_mode;
+    std::vector<SourceSelectionInfo> prepared_channels;
+    std::vector<PlaybackAllocation> prepared_allocations;
+    std::string failure_detail;
+};
+
+struct AsyncToggleResult {
+    bool success = false;
+    bool enabled = false;
+    std::string failure_detail;
+};
+
+struct AsyncValidationResult {
+    unsigned long long generation = 0;
+    ValidationState state = ValidationState::NotReady;
+    std::string details;
+};
 
 enum ControlId {
     kIdTab = 100,
@@ -1338,6 +1386,12 @@ private:
             case WM_COMMAND: return self->OnCommand(LOWORD(wparam), HIWORD(wparam));
             case WM_NOTIFY: return self->OnNotify(reinterpret_cast<NMHDR*>(lparam));
             case WM_TIMER: return self->OnTimer(static_cast<UINT_PTR>(wparam));
+            case kMsgAsyncScanComplete: return self->OnAsyncScanComplete(reinterpret_cast<AsyncScanResult*>(lparam));
+            case kMsgAsyncConnectComplete: return self->OnAsyncConnectComplete(reinterpret_cast<AsyncConnectResult*>(lparam));
+            case kMsgAsyncSourcesComplete: return self->OnAsyncSourcesComplete(reinterpret_cast<AsyncSourcesResult*>(lparam));
+            case kMsgAsyncApplyPlanComplete: return self->OnAsyncApplyPlanComplete(reinterpret_cast<AsyncApplyPlanResult*>(lparam));
+            case kMsgAsyncToggleComplete: return self->OnAsyncToggleComplete(reinterpret_cast<AsyncToggleResult*>(lparam));
+            case kMsgAsyncValidationComplete: return self->OnAsyncValidationComplete(reinterpret_cast<AsyncValidationResult*>(lparam));
             case WM_CTLCOLORSTATIC: return self->OnCtlColor(reinterpret_cast<HDC>(wparam), reinterpret_cast<HWND>(lparam));
             case WM_ERASEBKGND: return self->OnEraseBackground(reinterpret_cast<HDC>(wparam));
             case WM_SIZE: return self->OnSize(LOWORD(lparam), HIWORD(lparam));
@@ -1970,6 +2024,9 @@ private:
     }
 
     bool ShouldRefreshValidation() const {
+        if (validation_in_progress_) {
+            return false;
+        }
         const DWORD now = GetTickCount();
         if (!validation_snapshot_ready_) {
             return true;
@@ -1978,6 +2035,8 @@ private:
     }
 
     void InvalidateValidationSnapshot() {
+        validation_in_progress_ = false;
+        ++validation_generation_;
         validation_snapshot_ready_ = false;
         last_validation_tick_ = 0;
         latest_validation_state_ = ValidationState::NotReady;
@@ -2267,6 +2326,190 @@ private:
     }
 
     LRESULT OnNotify(NMHDR* hdr) {
+        return 0;
+    }
+
+    LRESULT OnAsyncScanComplete(AsyncScanResult* result_ptr) {
+        std::unique_ptr<AsyncScanResult> result(result_ptr);
+        scan_in_progress_ = false;
+        discovered_wings_ = result ? std::move(result->wings) : std::vector<WingInfo>{};
+        RefreshDiscoveryControls(true);
+        auto& extension = ReaperExtension::Instance();
+        if (discovered_wings_.empty()) {
+            footer_message_ = L"Scan finished. No WING consoles were discovered on the network.";
+            if (result && result->show_feedback) {
+                ShowMessageBox("No WING consoles were discovered. Enter a manual IP if the console is on a reachable network path.",
+                               "WINGuard",
+                               0);
+            }
+        } else {
+            wchar_t buffer[160];
+            std::swprintf(buffer, sizeof(buffer) / sizeof(wchar_t),
+                          L"Scan finished. Found %zu WING console(s).", discovered_wings_.size());
+            footer_message_ = buffer;
+            if (discovered_wings_.size() == 1 && !extension.IsConnected()) {
+                StartConnectAsync(L"auto-connect", L"Connected to WING.");
+            }
+        }
+        RefreshAll();
+        return 0;
+    }
+
+    LRESULT OnAsyncConnectComplete(AsyncConnectResult* result_ptr) {
+        std::unique_ptr<AsyncConnectResult> result(result_ptr);
+        connect_in_progress_ = false;
+        if (result && result->success) {
+            InvalidateValidationSnapshot();
+            footer_message_ = result->success_footer.empty() ? L"Connected to WING." : result->success_footer;
+            if (pending_choose_sources_after_connect_) {
+                pending_choose_sources_after_connect_ = false;
+                StartChooseSourcesAsync();
+                return 0;
+            }
+            if (pending_apply_after_connect_) {
+                pending_apply_after_connect_ = false;
+                StartApplySetupAsync();
+                return 0;
+            }
+            if (pending_toggle_after_connect_) {
+                pending_toggle_after_connect_ = false;
+                StartToggleSoundcheckAsync();
+                return 0;
+            }
+        } else {
+            pending_choose_sources_after_connect_ = false;
+            pending_apply_after_connect_ = false;
+            pending_toggle_after_connect_ = false;
+            std::string message = "WINGuard could not connect to the configured WING.";
+            if (result && !result->failure_detail.empty()) {
+                message += "\n\nFailure detail:\n" + result->failure_detail;
+            }
+            ShowMessageBox(message.c_str(), "WINGuard", 0);
+            footer_message_ = L"Connection to WING failed.";
+        }
+        RefreshAll();
+        return 0;
+    }
+
+    LRESULT OnAsyncSourcesComplete(AsyncSourcesResult* result_ptr) {
+        std::unique_ptr<AsyncSourcesResult> result(result_ptr);
+        source_load_in_progress_ = false;
+        if (!result || !result->success || result->channels.empty()) {
+            std::string message = "Connected, but no selectable sources were discovered.";
+            if (result && !result->failure_detail.empty()) {
+                message += "\n\nFailure detail:\n" + result->failure_detail;
+            }
+            ShowMessageBox(message.c_str(), "WINGuard", 0);
+            footer_message_ = L"No selectable sources were discovered.";
+            RefreshAll();
+            return 0;
+        }
+
+        if (!result->used_pending_draft) {
+            ApplyPendingSelectionOverlay(result->channels);
+        }
+
+        SourcePickerDialog picker(hwnd_,
+                                  std::move(result->channels),
+                                  pending_setup_soundcheck_,
+                                  pending_replace_existing_);
+        SourcePickerResult picker_result = picker.Run();
+        if (!picker_result.confirmed) {
+            footer_message_ = L"Source review cancelled.";
+            RefreshAll();
+            return 0;
+        }
+        size_t selected_count = 0;
+        for (const auto& channel : picker_result.channels) {
+            if (channel.selected) {
+                ++selected_count;
+            }
+        }
+        if (selected_count == 0) {
+            ShowMessageBox("No sources were selected for the next apply.", "WINGuard", 0);
+            footer_message_ = L"No sources were staged.";
+            RefreshAll();
+            return 0;
+        }
+        has_pending_setup_draft_ = true;
+        pending_setup_channels_ = std::move(picker_result.channels);
+        pending_setup_soundcheck_ = picker_result.setup_soundcheck;
+        pending_replace_existing_ = picker_result.replace_existing;
+        pending_output_mode_ = CurrentOutputMode();
+        InvalidateValidationSnapshot();
+        footer_message_ = L"Live setup draft staged. Review the summary and click Apply Setup when ready.";
+        RefreshAll();
+        return 0;
+    }
+
+    LRESULT OnAsyncApplyPlanComplete(AsyncApplyPlanResult* result_ptr) {
+        std::unique_ptr<AsyncApplyPlanResult> result(result_ptr);
+        apply_plan_in_progress_ = false;
+        if (!result || !result->success || result->prepared_channels.empty()) {
+            std::string message = "WINGuard could not prepare the live setup plan.";
+            if (result && !result->failure_detail.empty()) {
+                message += "\n\nFailure detail:\n" + result->failure_detail;
+            }
+            ShowMessageBox(message.c_str(), "WINGuard", 0);
+            footer_message_ = L"Live setup preparation failed.";
+            RefreshAll();
+            return 0;
+        }
+
+        auto& extension = ReaperExtension::Instance();
+        extension.PauseAutoRecordForSetup();
+        extension.GetConfig().soundcheck_output_mode = result->output_mode;
+        if (extension.SetupSoundcheckFromPlan(result->prepared_channels,
+                                              result->prepared_allocations,
+                                              result->output_mode,
+                                              result->setup_soundcheck,
+                                              result->replace_existing)) {
+            has_pending_setup_draft_ = false;
+            pending_setup_channels_.clear();
+            pending_output_mode_ = ToWide(extension.GetConfig().soundcheck_output_mode);
+            SaveConfigIfPossible(extension);
+            InvalidateValidationSnapshot();
+            footer_message_ = L"Live recording setup applied.";
+        } else {
+            InvalidateValidationSnapshot();
+            footer_message_ = L"Setup apply returned without success confirmation.";
+        }
+        RefreshAll();
+        return 0;
+    }
+
+    LRESULT OnAsyncToggleComplete(AsyncToggleResult* result_ptr) {
+        std::unique_ptr<AsyncToggleResult> result(result_ptr);
+        toggle_in_progress_ = false;
+        if (!result || !result->success) {
+            std::string message = "WINGuard could not change soundcheck mode.";
+            if (result && !result->failure_detail.empty()) {
+                message += "\n\nFailure detail:\n" + result->failure_detail;
+            }
+            ShowMessageBox(message.c_str(), "WINGuard", 0);
+            footer_message_ = L"Soundcheck mode change failed.";
+            RefreshAll();
+            return 0;
+        }
+        InvalidateValidationSnapshot();
+        footer_message_ = result->enabled
+            ? L"Soundcheck mode enabled."
+            : L"Live mode restored.";
+        RefreshAll();
+        return 0;
+    }
+
+    LRESULT OnAsyncValidationComplete(AsyncValidationResult* result_ptr) {
+        std::unique_ptr<AsyncValidationResult> result(result_ptr);
+        validation_in_progress_ = false;
+        if (!result || result->generation != validation_generation_) {
+            return 0;
+        }
+        latest_validation_state_ = result->state;
+        latest_validation_details_ = std::move(result->details);
+        last_validation_tick_ = GetTickCount();
+        validation_snapshot_ready_ = true;
+        RefreshAll();
         return 0;
     }
 
@@ -2737,10 +2980,36 @@ private:
         UpdateAutoTriggerUI();
         UpdateWingTabUI();
         UpdateControlTabUI();
-        EnableWindow(apply_setup_button_, snapshot.can_apply ? TRUE : FALSE);
-        EnableWindow(discard_setup_button_, snapshot.can_discard ? TRUE : FALSE);
-        EnableWindow(toggle_soundcheck_button_, snapshot.can_toggle ? TRUE : FALSE);
-        SetWindowTextIfChanged(connect_button_, ReaperExtension::Instance().IsConnected() ? L"Disconnect" : L"Connect");
+        const bool async_busy = scan_in_progress_ || connect_in_progress_ || source_load_in_progress_ ||
+                                apply_plan_in_progress_ || toggle_in_progress_;
+        EnableWindow(scan_button_, async_busy ? FALSE : TRUE);
+        EnableWindow(wing_combo_, async_busy ? FALSE : TRUE);
+        EnableWindow(manual_ip_edit_, async_busy ? FALSE : TRUE);
+        EnableWindow(connect_button_, async_busy ? FALSE : TRUE);
+        EnableWindow(choose_sources_button_, async_busy ? FALSE : TRUE);
+        EnableWindow(apply_setup_button_, (!async_busy && snapshot.can_apply) ? TRUE : FALSE);
+        EnableWindow(discard_setup_button_, (!async_busy && snapshot.can_discard) ? TRUE : FALSE);
+        EnableWindow(toggle_soundcheck_button_, (!async_busy && snapshot.can_toggle) ? TRUE : FALSE);
+        if (scan_in_progress_) {
+            SetWindowTextIfChanged(scan_button_, L"Scanning...");
+        } else {
+            SetWindowTextIfChanged(scan_button_, L"Scan");
+        }
+        if (connect_in_progress_) {
+            SetWindowTextIfChanged(connect_button_, L"Connecting...");
+        } else {
+            SetWindowTextIfChanged(connect_button_, ReaperExtension::Instance().IsConnected() ? L"Disconnect" : L"Connect");
+        }
+        if (apply_plan_in_progress_) {
+            SetWindowTextIfChanged(apply_setup_button_, L"Preparing...");
+        } else {
+            SetWindowTextIfChanged(apply_setup_button_, snapshot.apply_label);
+        }
+        if (toggle_in_progress_) {
+            SetWindowTextIfChanged(toggle_soundcheck_button_, L"Switching...");
+        } else {
+            SetWindowTextIfChanged(toggle_soundcheck_button_, snapshot.toggle_label);
+        }
 
         if (previous_snapshot.console.color != snapshot.console.color || previous_snapshot.console.text != snapshot.console.text) {
             redraw_control(header_console_icon_);
@@ -2835,6 +3104,158 @@ private:
         return true;
     }
 
+    void StartConnectAsync(const wchar_t* context, std::wstring success_footer) {
+        if (connect_in_progress_) {
+            return;
+        }
+        std::wstring ip = SelectedOrManualIp();
+        if (ip.empty()) {
+            wchar_t message[256];
+            std::swprintf(message, sizeof(message) / sizeof(wchar_t),
+                          L"No WING IP is selected. Scan or enter a manual IP before %ls.", context);
+            ShowMessageBox(ToUtf8(message).c_str(), "WINGuard", 0);
+            return;
+        }
+        auto& extension = ReaperExtension::Instance();
+        extension.GetConfig().wing_ip = ToUtf8(ip);
+        SaveConfigIfPossible(extension);
+        connect_in_progress_ = true;
+        footer_message_ = std::wstring(L"Connecting to WING for ") + context + L"...";
+        RefreshAll();
+        HWND target = hwnd_;
+        const std::string ip_utf8 = ToUtf8(ip);
+        std::thread([target, ip_utf8, success_footer = std::move(success_footer)]() {
+            auto result = std::make_unique<AsyncConnectResult>();
+            auto& extension = ReaperExtension::Instance();
+            extension.GetConfig().wing_ip = ip_utf8;
+            result->success = extension.ConnectToWing();
+            result->ip = ip_utf8;
+            result->success_footer = success_footer;
+            if (!result->success) {
+                result->failure_detail = extension.GetLastConnectionFailureDetail();
+            }
+            if (!PostMessageW(target, kMsgAsyncConnectComplete, 0, reinterpret_cast<LPARAM>(result.get()))) {
+                return;
+            }
+            result.release();
+        }).detach();
+    }
+
+    void StartChooseSourcesAsync() {
+        source_load_in_progress_ = true;
+        footer_message_ = L"Loading selectable sources...";
+        RefreshAll();
+        HWND target = hwnd_;
+        const bool use_pending_draft = has_pending_setup_draft_ && !pending_setup_channels_.empty();
+        const auto pending_channels = pending_setup_channels_;
+        std::thread([target, use_pending_draft, pending_channels]() {
+            auto result = std::make_unique<AsyncSourcesResult>();
+            result->used_pending_draft = use_pending_draft;
+            auto& extension = ReaperExtension::Instance();
+            if (!extension.IsConnected()) {
+                result->failure_detail = "Not connected to a WING.";
+            } else if (use_pending_draft) {
+                result->channels = pending_channels;
+                result->success = !result->channels.empty();
+            } else {
+                result->channels = extension.GetAvailableSources();
+                result->success = !result->channels.empty();
+            }
+            if (!PostMessageW(target, kMsgAsyncSourcesComplete, 0, reinterpret_cast<LPARAM>(result.get()))) {
+                return;
+            }
+            result.release();
+        }).detach();
+    }
+
+    void StartApplySetupAsync() {
+        if (apply_plan_in_progress_) {
+            return;
+        }
+        apply_plan_in_progress_ = true;
+        footer_message_ = L"Preparing live setup...";
+        RefreshAll();
+        HWND target = hwnd_;
+        const bool has_pending_draft = has_pending_setup_draft_;
+        const auto pending_channels = pending_setup_channels_;
+        const bool setup_soundcheck = pending_setup_soundcheck_;
+        const bool replace_existing = pending_replace_existing_;
+        const std::string output_mode = ToUtf8(pending_output_mode_);
+        std::thread([target, has_pending_draft, pending_channels, setup_soundcheck, replace_existing, output_mode]() {
+            auto result = std::make_unique<AsyncApplyPlanResult>();
+            auto& extension = ReaperExtension::Instance();
+            std::vector<SourceSelectionInfo> channels_to_apply;
+            if (has_pending_draft) {
+                channels_to_apply = pending_channels;
+            } else {
+                channels_to_apply = extension.GetAvailableSources();
+            }
+            size_t selected_count = 0;
+            for (const auto& channel : channels_to_apply) {
+                if (channel.selected) {
+                    ++selected_count;
+                }
+            }
+            if (selected_count == 0) {
+                result->failure_detail = "No sources are staged for apply.";
+            } else if (!extension.PrepareSoundcheckPlan(channels_to_apply,
+                                                        result->prepared_channels,
+                                                        result->prepared_allocations,
+                                                        result->failure_detail)) {
+                // failure_detail already filled by PrepareSoundcheckPlan.
+            } else {
+                result->success = true;
+                result->setup_soundcheck = setup_soundcheck;
+                result->replace_existing = replace_existing;
+                result->output_mode = output_mode;
+            }
+            if (!PostMessageW(target, kMsgAsyncApplyPlanComplete, 0, reinterpret_cast<LPARAM>(result.get()))) {
+                return;
+            }
+            result.release();
+        }).detach();
+    }
+
+    void StartToggleSoundcheckAsync() {
+        if (toggle_in_progress_) {
+            return;
+        }
+        toggle_in_progress_ = true;
+        footer_message_ = L"Toggling soundcheck mode...";
+        RefreshAll();
+        HWND target = hwnd_;
+        const bool enable = !ReaperExtension::Instance().IsSoundcheckModeEnabled();
+        std::thread([target, enable]() {
+            auto result = std::make_unique<AsyncToggleResult>();
+            std::string failure_detail;
+            result->enabled = enable;
+            result->success = ReaperExtension::Instance().SetSoundcheckModeEnabled(enable, &failure_detail);
+            result->failure_detail = failure_detail;
+            if (!PostMessageW(target, kMsgAsyncToggleComplete, 0, reinterpret_cast<LPARAM>(result.get()))) {
+                return;
+            }
+            result.release();
+        }).detach();
+    }
+
+    void StartValidationAsync() {
+        if (validation_in_progress_ || !hwnd_) {
+            return;
+        }
+        validation_in_progress_ = true;
+        const unsigned long long generation = validation_generation_;
+        HWND target = hwnd_;
+        std::thread([target, generation]() {
+            auto result = std::make_unique<AsyncValidationResult>();
+            result->generation = generation;
+            result->state = ReaperExtension::Instance().ValidateLiveRecordingSetup(result->details);
+            if (!PostMessageW(target, kMsgAsyncValidationComplete, 0, reinterpret_cast<LPARAM>(result.get()))) {
+                return;
+            }
+            result.release();
+        }).detach();
+    }
+
     StatusSnapshot BuildSnapshot() {
         StatusSnapshot snapshot;
         auto& extension = ReaperExtension::Instance();
@@ -2845,15 +3266,11 @@ private:
         const bool should_validate_now = connected && !has_pending_setup_draft_ && staged_output == applied_output;
 
         if (should_validate_now && ShouldRefreshValidation()) {
-            latest_validation_details_.clear();
-            latest_validation_state_ = ValidationState::NotReady;
-            latest_validation_state_ = extension.ValidateLiveRecordingSetup(latest_validation_details_);
-            last_validation_tick_ = GetTickCount();
-            validation_snapshot_ready_ = true;
+            StartValidationAsync();
         } else if (!should_validate_now) {
-            latest_validation_details_.clear();
-            latest_validation_state_ = ValidationState::NotReady;
-            validation_snapshot_ready_ = false;
+            if (validation_snapshot_ready_ || validation_in_progress_ || !latest_validation_details_.empty()) {
+                InvalidateValidationSnapshot();
+            }
         }
 
         snapshot.console = connected
@@ -2862,6 +3279,8 @@ private:
 
         if (has_pending_setup_draft_ || staged_output != applied_output) {
             snapshot.validation = MakeStatus(L"Reaper Recorder: Pending Apply", RGB(215, 135, 30));
+        } else if (connected && validation_in_progress_ && !validation_snapshot_ready_) {
+            snapshot.validation = MakeStatus(L"Reaper Recorder: Checking...", RGB(215, 135, 30));
         } else if (latest_validation_state_ == ValidationState::Ready) {
             if (config.auto_record_enabled) {
                 snapshot.validation = MakeStatus(
@@ -2947,6 +3366,11 @@ private:
                 L"Pending setup changes are staged. Applying them will update WING routing, REAPER tracks, and playback inputs for the selected sources.\r\n"
                 L"Next step: review the staged draft, then click Apply Setup.";
             snapshot.readiness_color = RGB(215, 135, 30);
+        } else if (validation_in_progress_ && !validation_snapshot_ready_) {
+            snapshot.readiness_detail =
+                L"Checking the current live setup against WING and REAPER.\r\n"
+                L"Next step: wait for validation to finish, then review whether the managed setup is ready or needs rebuild.";
+            snapshot.readiness_color = RGB(95, 95, 95);
         } else if (!latest_validation_details_.empty()) {
             snapshot.readiness_detail = ToWide(latest_validation_details_);
             if (latest_validation_state_ == ValidationState::Ready) {
@@ -3019,28 +3443,27 @@ private:
         }
     }
 
-    void RunScan(bool show_feedback = true) {
-        auto& extension = ReaperExtension::Instance();
-        discovered_wings_ = extension.DiscoverWings(1500);
-        RefreshDiscoveryControls(true);
-        if (discovered_wings_.empty()) {
-            footer_message_ = L"Scan finished. No WING consoles were discovered on the network.";
-            if (show_feedback) {
-                ShowMessageBox("No WING consoles were discovered. Enter a manual IP if the console is on a reachable network path.",
-                               "WINGuard",
-                               0);
-            }
-        } else {
-            wchar_t buffer[160];
-            std::swprintf(buffer, sizeof(buffer) / sizeof(wchar_t),
-                          L"Scan finished. Found %zu WING console(s).", discovered_wings_.size());
-            footer_message_ = buffer;
-            if (discovered_wings_.size() == 1 && !extension.IsConnected()) {
-                OnConnectClicked();
+    void StartScanAsync(bool show_feedback = true) {
+        if (scan_in_progress_) {
+            return;
+        }
+        scan_in_progress_ = true;
+        footer_message_ = L"Scanning for WING consoles...";
+        RefreshAll();
+        HWND target = hwnd_;
+        std::thread([target, show_feedback]() {
+            auto result = std::make_unique<AsyncScanResult>();
+            result->wings = ReaperExtension::Instance().DiscoverWings(1500);
+            result->show_feedback = show_feedback;
+            if (!PostMessageW(target, kMsgAsyncScanComplete, 0, reinterpret_cast<LPARAM>(result.get()))) {
                 return;
             }
-        }
-        RefreshAll();
+            result.release();
+        }).detach();
+    }
+
+    void RunScan(bool show_feedback = true) {
+        StartScanAsync(show_feedback);
     }
 
     void OnWingSelectionChanged() {
@@ -3066,6 +3489,10 @@ private:
 
     void OnConnectClicked() {
         auto& extension = ReaperExtension::Instance();
+        if (connect_in_progress_ || source_load_in_progress_) {
+            return;
+        }
+        pending_choose_sources_after_connect_ = false;
         if (extension.IsConnected()) {
             extension.DisconnectFromWing();
             InvalidateValidationSnapshot();
@@ -3073,10 +3500,7 @@ private:
             RefreshAll();
             return;
         }
-        if (EnsureConnected(L"connecting")) {
-            InvalidateValidationSnapshot();
-            RefreshAll();
-        }
+        StartConnectAsync(L"connecting", L"Connected to WING.");
     }
 
     void OnOutputModeChanged() {
@@ -3110,88 +3534,27 @@ private:
     }
 
     void OnChooseSources() {
-        if (!EnsureConnected(L"loading sources")) {
-            RefreshAll();
+        if (connect_in_progress_ || source_load_in_progress_ || scan_in_progress_) {
             return;
         }
-        auto channels = ReaperExtension::Instance().GetAvailableSources();
-        if (channels.empty()) {
-            ShowMessageBox("Connected, but no selectable sources were discovered.", "WINGuard", 0);
-            footer_message_ = L"No selectable sources were discovered.";
-            RefreshAll();
+        if (!ReaperExtension::Instance().IsConnected()) {
+            pending_choose_sources_after_connect_ = true;
+            StartConnectAsync(L"loading sources", L"Connected to WING. Loading selectable sources...");
             return;
         }
-        ApplyPendingSelectionOverlay(channels);
-        SourcePickerDialog picker(hwnd_,
-                                  std::move(channels),
-                                  pending_setup_soundcheck_,
-                                  pending_replace_existing_);
-        SourcePickerResult result = picker.Run();
-        if (!result.confirmed) {
-            footer_message_ = L"Source review cancelled.";
-            RefreshAll();
-            return;
-        }
-        size_t selected_count = 0;
-        for (const auto& channel : result.channels) {
-            if (channel.selected) {
-                ++selected_count;
-            }
-        }
-        if (selected_count == 0) {
-            ShowMessageBox("No sources were selected for the next apply.", "WINGuard", 0);
-            footer_message_ = L"No sources were staged.";
-            RefreshAll();
-            return;
-        }
-        has_pending_setup_draft_ = true;
-        pending_setup_channels_ = std::move(result.channels);
-        pending_setup_soundcheck_ = result.setup_soundcheck;
-        pending_replace_existing_ = result.replace_existing;
-        pending_output_mode_ = CurrentOutputMode();
-        InvalidateValidationSnapshot();
-        footer_message_ = L"Live setup draft staged. Review the summary and click Apply Setup when ready.";
-        RefreshAll();
+        StartChooseSourcesAsync();
     }
 
     void OnApplySetup() {
-        auto& extension = ReaperExtension::Instance();
-        if (!EnsureConnected(L"applying setup")) {
-            RefreshAll();
+        if (connect_in_progress_ || source_load_in_progress_ || scan_in_progress_ || apply_plan_in_progress_ || toggle_in_progress_) {
             return;
         }
-        std::vector<SourceSelectionInfo> channels_to_apply;
-        if (has_pending_setup_draft_) {
-            channels_to_apply = pending_setup_channels_;
-        } else {
-            channels_to_apply = extension.GetAvailableSources();
-        }
-        size_t selected_count = 0;
-        for (const auto& channel : channels_to_apply) {
-            if (channel.selected) {
-                ++selected_count;
-            }
-        }
-        if (selected_count == 0) {
-            ShowMessageBox("No sources are staged for apply.", "WINGuard", 0);
-            footer_message_ = L"No staged sources are available to apply.";
-            RefreshAll();
+        if (!ReaperExtension::Instance().IsConnected()) {
+            pending_apply_after_connect_ = true;
+            StartConnectAsync(L"applying setup", L"Connected to WING. Preparing live setup...");
             return;
         }
-        extension.PauseAutoRecordForSetup();
-        extension.GetConfig().soundcheck_output_mode = ToUtf8(pending_output_mode_);
-        if (extension.SetupSoundcheckFromSelection(channels_to_apply, pending_setup_soundcheck_, pending_replace_existing_)) {
-            has_pending_setup_draft_ = false;
-            pending_setup_channels_.clear();
-            pending_output_mode_ = ToWide(extension.GetConfig().soundcheck_output_mode);
-            SaveConfigIfPossible(extension);
-            InvalidateValidationSnapshot();
-            footer_message_ = L"Live recording setup applied.";
-        } else {
-            InvalidateValidationSnapshot();
-            footer_message_ = L"Setup apply returned without success confirmation.";
-        }
-        RefreshAll();
+        StartApplySetupAsync();
     }
 
     void OnDiscardSetup() {
@@ -3207,17 +3570,15 @@ private:
     }
 
     void OnToggleSoundcheck() {
-        auto& extension = ReaperExtension::Instance();
-        if (!EnsureConnected(L"toggling soundcheck mode")) {
-            RefreshAll();
+        if (connect_in_progress_ || source_load_in_progress_ || scan_in_progress_ || apply_plan_in_progress_ || toggle_in_progress_) {
             return;
         }
-        extension.ToggleSoundcheckMode();
-        InvalidateValidationSnapshot();
-        footer_message_ = extension.IsSoundcheckModeEnabled()
-            ? L"Soundcheck mode enabled."
-            : L"Live mode restored.";
-        RefreshAll();
+        if (!ReaperExtension::Instance().IsConnected()) {
+            pending_toggle_after_connect_ = true;
+            StartConnectAsync(L"toggling soundcheck mode", L"Connected to WING. Toggling soundcheck mode...");
+            return;
+        }
+        StartToggleSoundcheckAsync();
     }
 
     void SyncPendingSettingsFromConfig() {
@@ -3504,6 +3865,8 @@ private:
     std::string latest_validation_details_;
     DWORD last_validation_tick_ = 0;
     bool validation_snapshot_ready_ = false;
+    bool validation_in_progress_ = false;
+    unsigned long long validation_generation_ = 1;
     std::wstring footer_message_;
     StatusSnapshot current_snapshot_;
     int current_tab_index_ = 0;
@@ -3516,6 +3879,14 @@ private:
     int pending_warning_layer_ = 1;
     bool midi_actions_dirty_ = false;
     int last_monitor_track_count_ = -1;
+    bool scan_in_progress_ = false;
+    bool connect_in_progress_ = false;
+    bool source_load_in_progress_ = false;
+    bool apply_plan_in_progress_ = false;
+    bool toggle_in_progress_ = false;
+    bool pending_choose_sources_after_connect_ = false;
+    bool pending_apply_after_connect_ = false;
+    bool pending_toggle_after_connect_ = false;
     std::mutex log_buffer_mutex_;
     std::wstring pending_log_buffer_;
     DebugLogPopup debug_log_popup_;

--- a/src/ui/wing_connector_dialog_windows.cpp
+++ b/src/ui/wing_connector_dialog_windows.cpp
@@ -48,6 +48,7 @@ constexpr int kMinWindowHeight = 860;
 constexpr UINT_PTR kRefreshTimerId = 101;
 constexpr UINT kRefreshTimerMs = 500;
 constexpr int kScrollLineStep = 36;
+constexpr unsigned long kValidationRefreshIntervalMs = 1500;
 
 enum ControlId {
     kIdTab = 100,
@@ -182,6 +183,17 @@ std::wstring ReadWindowText(HWND hwnd) {
     }
     text.resize(static_cast<size_t>(std::max(length, 0)));
     return text;
+}
+
+bool SetWindowTextIfChanged(HWND hwnd, const std::wstring& text) {
+    if (!hwnd) {
+        return false;
+    }
+    if (ReadWindowText(hwnd) == text) {
+        return false;
+    }
+    SetWindowTextW(hwnd, text.c_str());
+    return true;
 }
 
 void SetWindowFontRecursive(HWND hwnd, HFONT font) {
@@ -1240,6 +1252,11 @@ private:
                     return context->owner->HandlePageMessage(context->state, msg, wparam, lparam);
                 }
                 break;
+            case WM_ERASEBKGND:
+                if (context && context->owner && context->state) {
+                    return context->owner->OnPageEraseBackground(context->state, reinterpret_cast<HDC>(wparam));
+                }
+                break;
             case WM_COMMAND:
             case WM_NOTIFY:
             case WM_CTLCOLORSTATIC:
@@ -1329,6 +1346,8 @@ private:
                 ShowWindow(hwnd, SW_HIDE);
                 return 0;
             case WM_DESTROY:
+                KillTimer(hwnd, kRefreshTimerId);
+                ReaperExtension::Instance().SetLogCallback({});
                 self->hwnd_ = nullptr;
                 return 0;
             default:
@@ -1870,6 +1889,16 @@ private:
         return 1;
     }
 
+    LRESULT OnPageEraseBackground(PageLayoutState* page, HDC hdc) {
+        if (!page || !page->hwnd || !hdc) {
+            return 0;
+        }
+        RECT client{};
+        GetClientRect(page->hwnd, &client);
+        FillRect(hdc, &client, body_brush_);
+        return 1;
+    }
+
     LRESULT HandlePageMessage(PageLayoutState* page, UINT msg, WPARAM wparam, LPARAM lparam) {
         if (!page || !page->hwnd) {
             return 0;
@@ -1910,8 +1939,8 @@ private:
             const int delta_y = page->scroll_y - next_scroll;
             page->scroll_y = next_scroll;
             UpdatePageScroll(*page, PageViewportHeight(*page));
-            ScrollWindowEx(page->hwnd, 0, delta_y, nullptr, nullptr, nullptr, nullptr, SW_INVALIDATE | SW_SCROLLCHILDREN);
-            UpdateWindow(page->hwnd);
+            ScrollWindowEx(page->hwnd, 0, delta_y, nullptr, nullptr, nullptr, nullptr,
+                           SW_INVALIDATE | SW_ERASE | SW_SCROLLCHILDREN);
         }
         return 0;
     }
@@ -1938,6 +1967,21 @@ private:
 
     int PageY(const PageLayoutState& page, int content_y) const {
         return content_y - page.scroll_y;
+    }
+
+    bool ShouldRefreshValidation() const {
+        const DWORD now = GetTickCount();
+        if (!validation_snapshot_ready_) {
+            return true;
+        }
+        return (now - last_validation_tick_) >= kValidationRefreshIntervalMs;
+    }
+
+    void InvalidateValidationSnapshot() {
+        validation_snapshot_ready_ = false;
+        last_validation_tick_ = 0;
+        latest_validation_state_ = ValidationState::NotReady;
+        latest_validation_details_.clear();
     }
 
     void LayoutControls(int client_width, int client_height) {
@@ -2441,7 +2485,7 @@ private:
         } else {
             detail = L"Recorder coordination is aligned with the current setup and ready to be used.";
         }
-        SetWindowTextW(wing_placeholder_body_, detail.c_str());
+        SetWindowTextIfChanged(wing_placeholder_body_, detail);
         EnableWindow(apply_recorder_button_, recorder_settings_dirty_ ? TRUE : FALSE);
         EnableWindow(discard_recorder_button_, recorder_settings_dirty_ ? TRUE : FALSE);
     }
@@ -2450,15 +2494,18 @@ private:
         if (!auto_trigger_monitor_combo_) {
             return;
         }
-        auto& config = ReaperExtension::Instance().GetConfig();
-        SendMessageW(auto_trigger_monitor_combo_, CB_RESETCONTENT, 0, 0);
-        SendMessageW(auto_trigger_monitor_combo_, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(L"Auto (Armed+Monitored)"));
         const int track_count = ReaperExtension::Instance().GetProjectTrackCount();
-        for (int i = 1; i <= track_count; ++i) {
-            wchar_t label[64];
-            std::swprintf(label, sizeof(label) / sizeof(wchar_t), L"Track %d", i);
-            SendMessageW(auto_trigger_monitor_combo_, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(label));
+        if (track_count != last_monitor_track_count_) {
+            SendMessageW(auto_trigger_monitor_combo_, CB_RESETCONTENT, 0, 0);
+            SendMessageW(auto_trigger_monitor_combo_, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(L"Auto (Armed+Monitored)"));
+            for (int i = 1; i <= track_count; ++i) {
+                wchar_t label[64];
+                std::swprintf(label, sizeof(label) / sizeof(wchar_t), L"Track %d", i);
+                SendMessageW(auto_trigger_monitor_combo_, CB_ADDSTRING, 0, reinterpret_cast<LPARAM>(label));
+            }
+            last_monitor_track_count_ = track_count;
         }
+        auto& config = ReaperExtension::Instance().GetConfig();
         int wanted = std::max(0, pending_auto_record_monitor_track_);
         if (wanted > track_count) {
             wanted = 0;
@@ -2467,7 +2514,10 @@ private:
                 config.auto_record_monitor_track = 0;
             }
         }
-        SendMessageW(auto_trigger_monitor_combo_, CB_SETCURSEL, wanted, 0);
+        const LRESULT current_selection = SendMessageW(auto_trigger_monitor_combo_, CB_GETCURSEL, 0, 0);
+        if (current_selection != wanted) {
+            SendMessageW(auto_trigger_monitor_combo_, CB_SETCURSEL, wanted, 0);
+        }
     }
 
     void SyncAutoTriggerFromConfig() {
@@ -2564,8 +2614,8 @@ private:
         std::wstring hint = auto_trigger_dirty_
             ? L"Pending changes stay parked until you click Apply Auto Trigger Settings."
             : L"Warning mode flashes controls when triggered; Record mode starts and stops recording automatically.";
-        SetWindowTextW(auto_trigger_detail_, detail.c_str());
-        SetWindowTextW(auto_trigger_hint_, hint.c_str());
+        SetWindowTextIfChanged(auto_trigger_detail_, detail);
+        SetWindowTextIfChanged(auto_trigger_hint_, hint);
 
         EnableWindow(auto_trigger_enable_off_, live_setup_controls_enabled ? TRUE : FALSE);
         EnableWindow(auto_trigger_enable_on_, live_setup_controls_enabled ? TRUE : FALSE);
@@ -2591,8 +2641,8 @@ private:
         } else {
             detail = L"MIDI shortcuts are disabled. Enable them after live setup is validated if you want hands-on transport control from the console.";
         }
-        SetWindowTextW(midi_summary_, summary.c_str());
-        SetWindowTextW(midi_detail_, detail.c_str());
+        SetWindowTextIfChanged(midi_summary_, summary);
+        SetWindowTextIfChanged(midi_detail_, detail);
         EnableWindow(apply_midi_button_, midi_actions_dirty_ ? TRUE : FALSE);
         EnableWindow(discard_midi_button_, midi_actions_dirty_ ? TRUE : FALSE);
     }
@@ -2610,9 +2660,18 @@ private:
             chunk.swap(pending_log_buffer_);
         }
 
-        const std::wstring current = ReadWindowText(debug_log_view_);
-        std::wstring combined = current + chunk;
         constexpr size_t kMaxLogChars = 32000;
+        const int current_length = GetWindowTextLengthW(debug_log_view_);
+        if (current_length > 0 &&
+            (static_cast<size_t>(current_length) + chunk.size()) <= kMaxLogChars) {
+            SendMessageW(debug_log_view_, EM_SETSEL, current_length, current_length);
+            SendMessageW(debug_log_view_, EM_REPLACESEL, FALSE, reinterpret_cast<LPARAM>(chunk.c_str()));
+            SendMessageW(debug_log_view_, EM_SCROLLCARET, 0, 0);
+            debug_log_popup_.SetText(CurrentLogText());
+            return;
+        }
+
+        std::wstring combined = ReadWindowText(debug_log_view_) + chunk;
         if (combined.size() > kMaxLogChars) {
             combined = combined.substr(combined.size() - kMaxLogChars);
         }
@@ -2653,30 +2712,25 @@ private:
         const StatusSnapshot previous_snapshot = current_snapshot_;
         auto snapshot = BuildSnapshot();
         current_snapshot_ = snapshot;
-        auto update_text = [](HWND control, const std::wstring& text) {
-            if (control && ReadWindowText(control) != text) {
-                SetWindowTextW(control, text.c_str());
-            }
-        };
         auto redraw_control = [](HWND control) {
             if (control) {
-                RedrawWindow(control, nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW);
+                RedrawWindow(control, nullptr, nullptr, RDW_INVALIDATE);
             }
         };
 
-        update_text(header_console_status_, snapshot.console.text);
-        update_text(header_validation_status_, snapshot.validation.text);
-        update_text(header_recorder_status_, snapshot.recorder.text);
-        update_text(header_midi_status_, snapshot.midi.text);
-        update_text(tab_status_console_, snapshot.console_tab.text);
-        update_text(tab_status_reaper_, snapshot.reaper_tab.text);
-        update_text(tab_status_wing_, snapshot.wing_tab.text);
-        update_text(tab_status_control_, snapshot.control_tab.text);
-        update_text(pending_summary_, snapshot.pending_summary);
-        update_text(readiness_detail_, snapshot.readiness_detail);
-        update_text(footer_status_, snapshot.footer);
-        update_text(apply_setup_button_, snapshot.apply_label);
-        update_text(toggle_soundcheck_button_, snapshot.toggle_label);
+        SetWindowTextIfChanged(header_console_status_, snapshot.console.text);
+        SetWindowTextIfChanged(header_validation_status_, snapshot.validation.text);
+        SetWindowTextIfChanged(header_recorder_status_, snapshot.recorder.text);
+        SetWindowTextIfChanged(header_midi_status_, snapshot.midi.text);
+        SetWindowTextIfChanged(tab_status_console_, snapshot.console_tab.text);
+        SetWindowTextIfChanged(tab_status_reaper_, snapshot.reaper_tab.text);
+        SetWindowTextIfChanged(tab_status_wing_, snapshot.wing_tab.text);
+        SetWindowTextIfChanged(tab_status_control_, snapshot.control_tab.text);
+        SetWindowTextIfChanged(pending_summary_, snapshot.pending_summary);
+        SetWindowTextIfChanged(readiness_detail_, snapshot.readiness_detail);
+        SetWindowTextIfChanged(footer_status_, snapshot.footer);
+        SetWindowTextIfChanged(apply_setup_button_, snapshot.apply_label);
+        SetWindowTextIfChanged(toggle_soundcheck_button_, snapshot.toggle_label);
         UpdateAutoTriggerMeterPreview();
         FlushPendingLogBuffer();
         RefreshMonitorTrackDropdown();
@@ -2686,7 +2740,7 @@ private:
         EnableWindow(apply_setup_button_, snapshot.can_apply ? TRUE : FALSE);
         EnableWindow(discard_setup_button_, snapshot.can_discard ? TRUE : FALSE);
         EnableWindow(toggle_soundcheck_button_, snapshot.can_toggle ? TRUE : FALSE);
-        update_text(connect_button_, ReaperExtension::Instance().IsConnected() ? L"Disconnect" : L"Connect");
+        SetWindowTextIfChanged(connect_button_, ReaperExtension::Instance().IsConnected() ? L"Disconnect" : L"Connect");
 
         if (previous_snapshot.console.color != snapshot.console.color || previous_snapshot.console.text != snapshot.console.text) {
             redraw_control(header_console_icon_);
@@ -2788,11 +2842,18 @@ private:
         const bool connected = extension.IsConnected();
         const std::wstring applied_output = ToWide(config.soundcheck_output_mode);
         const std::wstring staged_output = pending_output_mode_.empty() ? applied_output : pending_output_mode_;
+        const bool should_validate_now = connected && !has_pending_setup_draft_ && staged_output == applied_output;
 
-        latest_validation_details_.clear();
-        latest_validation_state_ = ValidationState::NotReady;
-        if (connected && !has_pending_setup_draft_ && staged_output == applied_output) {
+        if (should_validate_now && ShouldRefreshValidation()) {
+            latest_validation_details_.clear();
+            latest_validation_state_ = ValidationState::NotReady;
             latest_validation_state_ = extension.ValidateLiveRecordingSetup(latest_validation_details_);
+            last_validation_tick_ = GetTickCount();
+            validation_snapshot_ready_ = true;
+        } else if (!should_validate_now) {
+            latest_validation_details_.clear();
+            latest_validation_state_ = ValidationState::NotReady;
+            validation_snapshot_ready_ = false;
         }
 
         snapshot.console = connected
@@ -3007,11 +3068,13 @@ private:
         auto& extension = ReaperExtension::Instance();
         if (extension.IsConnected()) {
             extension.DisconnectFromWing();
+            InvalidateValidationSnapshot();
             footer_message_ = L"Disconnected from WING.";
             RefreshAll();
             return;
         }
         if (EnsureConnected(L"connecting")) {
+            InvalidateValidationSnapshot();
             RefreshAll();
         }
     }
@@ -3020,6 +3083,7 @@ private:
         const std::wstring current_mode = CurrentOutputMode();
         const std::wstring applied_mode = ToWide(ReaperExtension::Instance().GetConfig().soundcheck_output_mode);
         pending_output_mode_ = current_mode;
+        InvalidateValidationSnapshot();
         if (!has_pending_setup_draft_ && pending_output_mode_ == applied_mode) {
             footer_message_ = L"Recording mode matches the applied setup.";
         } else if (!has_pending_setup_draft_) {
@@ -3085,6 +3149,7 @@ private:
         pending_setup_soundcheck_ = result.setup_soundcheck;
         pending_replace_existing_ = result.replace_existing;
         pending_output_mode_ = CurrentOutputMode();
+        InvalidateValidationSnapshot();
         footer_message_ = L"Live setup draft staged. Review the summary and click Apply Setup when ready.";
         RefreshAll();
     }
@@ -3120,8 +3185,10 @@ private:
             pending_setup_channels_.clear();
             pending_output_mode_ = ToWide(extension.GetConfig().soundcheck_output_mode);
             SaveConfigIfPossible(extension);
+            InvalidateValidationSnapshot();
             footer_message_ = L"Live recording setup applied.";
         } else {
+            InvalidateValidationSnapshot();
             footer_message_ = L"Setup apply returned without success confirmation.";
         }
         RefreshAll();
@@ -3134,6 +3201,7 @@ private:
         pending_replace_existing_ = true;
         pending_output_mode_ = ToWide(ReaperExtension::Instance().GetConfig().soundcheck_output_mode);
         SelectOutputMode(ToUtf8(pending_output_mode_));
+        InvalidateValidationSnapshot();
         footer_message_ = L"Staged setup changes discarded.";
         RefreshAll();
     }
@@ -3145,6 +3213,7 @@ private:
             return;
         }
         extension.ToggleSoundcheckMode();
+        InvalidateValidationSnapshot();
         footer_message_ = extension.IsSoundcheckModeEnabled()
             ? L"Soundcheck mode enabled."
             : L"Live mode restored.";
@@ -3433,6 +3502,8 @@ private:
     bool auto_trigger_dirty_ = false;
     ValidationState latest_validation_state_ = ValidationState::NotReady;
     std::string latest_validation_details_;
+    DWORD last_validation_tick_ = 0;
+    bool validation_snapshot_ready_ = false;
     std::wstring footer_message_;
     StatusSnapshot current_snapshot_;
     int current_tab_index_ = 0;
@@ -3444,6 +3515,7 @@ private:
     bool pending_midi_actions_enabled_ = false;
     int pending_warning_layer_ = 1;
     bool midi_actions_dirty_ = false;
+    int last_monitor_track_count_ = -1;
     std::mutex log_buffer_mutex_;
     std::wstring pending_log_buffer_;
     DebugLogPopup debug_log_popup_;


### PR DESCRIPTION
## Summary
- reduce Windows repaint churn and move scan, connect, source loading, apply-plan prep, toggle, and validation work off the UI thread where safe
- improve macOS dialog responsiveness with buffered logs, cached source loading, a lighter chooser flow, and a dedicated source chooser panel
- cache shared source and validation snapshots to cut repeated synchronous backend work across both platforms

## Validation
- `./build.sh`
- manual macOS validation during scan, connect, choose sources, apply setup, toggle soundcheck, and chooser scrolling
- daily release published: `v1.2.0.0-daily-20260403.3`

## Notes
- the final setup apply step still performs REAPER/project mutation synchronously by design
- the shipped daily release can be used for Windows verification and review