### PR TITLE
fix: make Windows plugin installer self-contained

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,13 @@ jobs:
           git clone --depth 1 https://github.com/RossBencina/oscpack.git lib/oscpack
           test -f "lib/oscpack/osc/OscOutboundPacketStream.h"
 
-      - name: Configure (CMake)
+      - name: Configure (CMake, macOS)
+        if: runner.os == 'macOS'
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Configure (CMake, Windows x64)
+        if: runner.os == 'Windows'
+        run: cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
 
       - name: Build
         shell: bash
@@ -68,6 +73,11 @@ jobs:
 
       - name: Stage install
         run: cmake --install build --config Release --prefix stage
+
+      - name: Validate Windows plugin binary
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./packaging/validate_windows_binary.ps1 -PluginPath stage/reaper_wingconnector.dll
 
       - name: Upload staged artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,8 @@ jobs:
           git clone --depth 1 https://github.com/RossBencina/oscpack.git lib/oscpack
           test -f "lib/oscpack/osc/OscOutboundPacketStream.h"
 
-      - name: Configure (CMake, macOS)
-        if: runner.os == 'macOS'
+      - name: Configure (CMake)
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-
-      - name: Configure (CMake, Windows x64)
-        if: runner.os == 'Windows'
-        run: cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
 
       - name: Build
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,13 @@ jobs:
           CLEAN_VERSION="${RAW_VERSION#v}"
           echo "VERSION=${CLEAN_VERSION}" >> "$GITHUB_ENV"
 
-      - name: Configure (CMake)
+      - name: Configure (CMake, macOS)
+        if: runner.os == 'macOS'
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Configure (CMake, Windows x64)
+        if: runner.os == 'Windows'
+        run: cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
 
       - name: Build
         shell: bash
@@ -75,6 +80,11 @@ jobs:
 
       - name: Stage install
         run: cmake --install build --config Release --prefix stage
+
+      - name: Validate Windows plugin binary
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./packaging/validate_windows_binary.ps1 -PluginPath stage/reaper_wingconnector.dll
 
       - name: Install Inno Setup
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,13 +55,8 @@ jobs:
           CLEAN_VERSION="${RAW_VERSION#v}"
           echo "VERSION=${CLEAN_VERSION}" >> "$GITHUB_ENV"
 
-      - name: Configure (CMake, macOS)
-        if: runner.os == 'macOS'
+      - name: Configure (CMake)
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-
-      - name: Configure (CMake, Windows x64)
-        if: runner.os == 'Windows'
-        run: cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
 
       - name: Build
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
+cmake_policy(SET CMP0091 NEW)
+
 project(AUDIOLABWingReaperVirtualSoundcheck VERSION 1.2.0.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -117,6 +119,11 @@ target_compile_definitions(reaper_wingconnector
 
 # Compiler flags
 if(MSVC)
+    # Keep the packaged extension self-contained so REAPER can load it on a
+    # clean Windows installation without a separate Visual C++ Redistributable.
+    set_property(TARGET reaper_wingconnector PROPERTY
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>"
+    )
     target_compile_options(
         reaper_wingconnector
         PRIVATE

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,6 +66,7 @@ Build system: `CMakeLists.txt`
   - `.dylib` on macOS
   - `.dll` on Windows
 - Links platform dependencies conditionally.
+- Builds the Windows release as x64 with a statically linked MSVC runtime, and validates the staged DLL before installer creation.
 - Uses `oscpack` and REAPER SDK headers.
 
 CI/CD:

--- a/packaging/create_installer_windows.ps1
+++ b/packaging/create_installer_windows.ps1
@@ -14,7 +14,15 @@ $stagePath = (Resolve-Path $StageDir).Path
 if (-not (Test-Path (Join-Path $stagePath $pluginName))) {
     throw "Missing $pluginName in $stagePath"
 }
+
+$validatorPath = Join-Path $PSScriptRoot 'validate_windows_binary.ps1'
+& $validatorPath -PluginPath (Join-Path $stagePath $pluginName)
+
 $hasConfig = Test-Path (Join-Path $stagePath $configName)
+$configFileEntry = ''
+if ($hasConfig) {
+    $configFileEntry = "Source: `"$stagePath\$configName`"; DestDir: `"{userappdata}\REAPER\UserPlugins`"; Flags: onlyifdoesntexist uninsneveruninstall"
+}
 
 New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
 $outPath = (Resolve-Path $OutDir).Path
@@ -55,16 +63,14 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
 Source: "$stagePath\$pluginName"; DestDir: "{userappdata}\REAPER\UserPlugins"; Flags: ignoreversion
+$configFileEntry
+
 [Icons]
 Name: "{autoprograms}\$appName\Uninstall $appName"; Filename: "{uninstallexe}"
 
 [Run]
 Filename: "{cmd}"; Parameters: "/c echo Installed to %APPDATA%\REAPER\UserPlugins"; Flags: runhidden
 "@
-
-if ($hasConfig) {
-    $iss += "`r`nSource: `"$stagePath\$configName`"; DestDir: `"{userappdata}\REAPER\UserPlugins`"; Flags: onlyifdoesntexist uninsneveruninstall`r`n"
-}
 
 Set-Content -Path $issPath -Value $iss -NoNewline
 

--- a/packaging/validate_windows_binary.ps1
+++ b/packaging/validate_windows_binary.ps1
@@ -1,0 +1,59 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PluginPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$resolvedPluginPath = (Resolve-Path $PluginPath).Path
+
+function Find-Dumpbin {
+    $command = Get-Command dumpbin.exe -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+    if (-not (Test-Path $vswhere)) {
+        return $null
+    }
+
+    $installationPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+    if (-not $installationPath) {
+        return $null
+    }
+
+    $candidate = Get-ChildItem -Path (Join-Path $installationPath 'VC\Tools\MSVC\*\bin\Hostx64\x64\dumpbin.exe') -ErrorAction SilentlyContinue |
+        Sort-Object FullName -Descending |
+        Select-Object -First 1
+    return $candidate.FullName
+}
+
+$dumpbin = Find-Dumpbin
+if ($dumpbin) {
+    $inspection = (& $dumpbin /headers /dependents $resolvedPluginPath 2>&1 | Out-String)
+} else {
+    $llvmReadobj = Get-Command llvm-readobj.exe -ErrorAction SilentlyContinue
+    if (-not $llvmReadobj) {
+        throw 'Neither dumpbin.exe nor llvm-readobj.exe was found; cannot validate the Windows plugin binary.'
+    }
+    $inspection = (& $llvmReadobj.Source --file-headers --coff-imports $resolvedPluginPath 2>&1 | Out-String)
+}
+
+if ($LASTEXITCODE -ne 0) {
+    throw "Binary inspection failed for $resolvedPluginPath`n$inspection"
+}
+
+if ($inspection -notmatch '(?i)(8664 machine \(x64\)|IMAGE_FILE_MACHINE_AMD64)') {
+    throw "Expected an x64 Windows plugin binary.`n$inspection"
+}
+
+$dynamicRuntimePattern = '(?i)\b(?:VCRUNTIME|MSVCP|CONCRT|UCRTBASED)[A-Z0-9_.-]*\.dll\b'
+$dynamicRuntimeImports = [regex]::Matches($inspection, $dynamicRuntimePattern) |
+    ForEach-Object { $_.Value.ToUpperInvariant() } |
+    Sort-Object -Unique
+if ($dynamicRuntimeImports) {
+    throw "Plugin imports dynamic MSVC runtime DLLs: $($dynamicRuntimeImports -join ', ')"
+}
+
+Write-Host "Validated self-contained x64 plugin: $resolvedPluginPath"


### PR DESCRIPTION
- Link the x64 plugin with the static MSVC runtime
- Reject invalid runtime imports before packaging
- Keep optional config files in the Inno Files section